### PR TITLE
improving readability in the logic tables

### DIFF
--- a/logic0_Casual.lua
+++ b/logic0_Casual.lua
@@ -53,7 +53,7 @@ infobots = {
   {id=0x0A, req_items={} },                                 -- Batalia -> Orxon
   {id=0x0B, req_items={} },                                 -- Orxon -> Pokitaru
   {id=0x0C, req_items={{keyid.o2_mask,keyid.swingshot,keyid.magneboots,keyid.thruster_pack}} },            -- Orxon -> Hoven
-  {id=0x0D, req_items={} },                                 -- Hoven -> Gemlik
+  {id=0x0D, req_items={{keyid.devastator}, {keyid.visibomb}, {keyid.blaster}} },                                 -- Hoven -> Gemlik
   {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.swingshot, keyid.magneboots,keyid.trespasser, keyid.visibomb}} },         -- Gemlik -> Oltanis
   {id=0x0F, req_items={{keyid.grindboots}} },                           -- Oltanis -> Quartu
   {id=0x10, req_items={{keyid.swingshot}} },                           -- Quartu -> KaleboIII

--- a/logic0_Casual.lua
+++ b/logic0_Casual.lua
@@ -41,24 +41,24 @@ items = {
 }
 
 infobots = {
-  {id=0x01, req_items={} },                                 -- Veldin1 -> Novalis
-  {id=0x02, req_items={} },                                 -- Novalis -> Aridia
-  {id=0x03, req_items={} },                                 -- Novalis -> Kerwan
-  {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} },                   -- Kerwan -> Eudora
-  {id=0x05, req_items={} },                                 -- Blarg -> Rilgar
+  {id=0x01, req_items={} }, -- Veldin1 -> Novalis
+  {id=0x02, req_items={} }, -- Novalis -> Aridia
+  {id=0x03, req_items={} }, -- Novalis -> Kerwan
+  {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} }, -- Kerwan -> Eudora
+  {id=0x05, req_items={} }, -- Blarg -> Rilgar
   {id=0x06, req_items={{keyid.trespasser,keyid.swingshot,keyid.heli_pack}, {keyid.trespasser,keyid.swingshot,keyid.thruster_pack}} }, -- Eudora -> Blarg
-  {id=0x07, req_items={{keyid.swingshot,keyid.hydrodisplacer}} },                      -- Rilgar -> Umbris
-  {id=0x08, req_items={{keyid.swingshot,keyid.hydrodisplacer}} },                      -- Umbris -> Batalia
-  {id=0x09, req_items={{keyid.grindboots}} },                           -- Batalia -> Gaspar
-  {id=0x0A, req_items={} },                                 -- Batalia -> Orxon
-  {id=0x0B, req_items={} },                                 -- Orxon -> Pokitaru
-  {id=0x0C, req_items={{keyid.o2_mask,keyid.swingshot,keyid.magneboots,keyid.thruster_pack}} },            -- Orxon -> Hoven
-  {id=0x0D, req_items={{keyid.devastator}, {keyid.visibomb}, {keyid.blaster}} },                                 -- Hoven -> Gemlik
-  {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.swingshot, keyid.magneboots,keyid.trespasser, keyid.visibomb}} },         -- Gemlik -> Oltanis
-  {id=0x0F, req_items={{keyid.grindboots}} },                           -- Oltanis -> Quartu
-  {id=0x10, req_items={{keyid.swingshot}} },                           -- Quartu -> KaleboIII
-  {id=0x11, req_items={{0x03,keyid.swingshot,keyid.hologuise}} },                 -- Quartu -> Fleet
-  {id=0x12, req_items={{keyid.magneboots,keyid.hologuise}} }                       -- Fleet -> Veldin2
+  {id=0x07, req_items={{keyid.swingshot,keyid.hydrodisplacer}} }, -- Rilgar -> Umbris
+  {id=0x08, req_items={{keyid.swingshot,keyid.hydrodisplacer}} }, -- Umbris -> Batalia
+  {id=0x09, req_items={{keyid.grindboots}} }, -- Batalia -> Gaspar
+  {id=0x0A, req_items={} }, -- Batalia -> Orxon
+  {id=0x0B, req_items={} }, -- Orxon -> Pokitaru
+  {id=0x0C, req_items={{keyid.o2_mask,keyid.swingshot,keyid.magneboots,keyid.thruster_pack}} }, -- Orxon -> Hoven
+  {id=0x0D, req_items={{keyid.devastator}, {keyid.visibomb}, {keyid.blaster}} }, -- Hoven -> Gemlik
+  {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.swingshot, keyid.magneboots,keyid.trespasser, keyid.visibomb}} }, -- Gemlik -> Oltanis
+  {id=0x0F, req_items={{keyid.grindboots}} }, -- Oltanis -> Quartu
+  {id=0x10, req_items={{keyid.swingshot}} }, -- Quartu -> KaleboIII
+  {id=0x11, req_items={{keyid.thruster_pack,keyid.swingshot,keyid.hologuise}} }, -- Quartu -> Fleet
+  {id=0x12, req_items={{keyid.magneboots,keyid.hologuise}} } -- Fleet -> Veldin2
 }
 
 planets = {
@@ -75,7 +75,7 @@ planets = {
   {id=11, name="Pokitaru", infobots={},                           items={keyid.thruster_pack,keyid.o2_mask,keyid.persuader,keyid.decoy_glove} },
   {id=12, name="Hoven",    infobots={keyid.gemlik},               items={keyid.raritanium,keyid.hydro_pack,keyid.drone_device} },
   {id=13, name="Gemlik",   infobots={keyid.oltanis},              items={} },
-  {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.PDA,keyid.tesla_claw,keyid.morph_o_ray} },
+  {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.pda,keyid.tesla_claw,keyid.morph_o_ray} },
   {id=15, name="Quartu",   infobots={keyid.kalebo,keyid.fleet},   items={keyid.bolt_grabber} },
   {id=16, name="KaleboIII",infobots={},                           items={keyid.hologuise,keyid.map_o_matic} },
   {id=17, name="Fleet",    infobots={keyid.veldin},               items={keyid.codebot} }

--- a/logic0_Casual.lua
+++ b/logic0_Casual.lua
@@ -1,11 +1,13 @@
+require 'table_id'
+
 items = {
   {id=0x02, name="Heli-pack",       req_items={} },
   {id=0x03, name="Thruster-pack",   req_items={} },
-  {id=0x04, name="Hydro-pack",      req_items={{0x16}} },
-  {id=0x05, name="Sonic Summoner",  req_items={{0x30}} },
-  {id=0x06, name="O2 Mask",         req_items={{0x07}} },
+  {id=0x04, name="Hydro-pack",      req_items={{keyid.hydrodisplacer}} },
+  {id=0x05, name="Sonic Summoner",  req_items={{keyid.zoomerator}} },
+  {id=0x06, name="O2 Mask",         req_items={{keyid.pilots_helmet}} },
   {id=0x07, name="Pilot's Helmet",  req_items={} },
-  {id=0x09, name="Suck Cannon",     req_items={{0x02}, {0x03}} },
+  {id=0x09, name="Suck Cannon",     req_items={{keyid.heli_pack}, {keyid.thruster_pack}} },
   {id=0x0B, name="Devastator",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
   {id=0x0C, name="Swingshot",       req_items={} },
   {id=0x0D, name="Visibomb",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
@@ -16,65 +18,65 @@ items = {
   {id=0x12, name="Walloper",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
   {id=0x13, name="Tesla Claw",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
   {id=0x14, name="Glove of Doom",   req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x15, name="Morph-O-Ray",     req_items={{0x0C}} },
-  {id=0x16, name="Hydrodisplacer",  req_items={{0x1A}} },
-  {id=0x17, name="R.Y.N.O.",        req_items={{0x1B,0x02}, {0x1B,0x03}} },
+  {id=0x15, name="Morph-O-Ray",     req_items={{keyid.swingshot}} },
+  {id=0x16, name="Hydrodisplacer",  req_items={{keyid.trespasser}} },
+  {id=0x17, name="R.Y.N.O.",        req_items={{keyid.metal_detector,keyid.heli_pack}, {keyid.metal_detector,keyid.thruster_pack}} },
   {id=0x18, name="Drone Device",    req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
   {id=0x19, name="Decoy Glove",     req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x1A, name="Trespasser",      req_items={{0x0C}} },
-  {id=0x1B, name="MetalDetector",   req_items={{0x1C}} },
+  {id=0x1A, name="Trespasser",      req_items={{keyid.swingshot}} },
+  {id=0x1B, name="MetalDetector",   req_items={{keyid.magneboots}} },
   {id=0x1C, name="Magneboots",      req_items={} },
-  {id=0x1D, name="Grindboots",      req_items={{0x0C}} },
+  {id=0x1D, name="Grindboots",      req_items={{keyid.swingshot}} },
   {id=0x1E, name="Hoverboard",      req_items={} },
-  {id=0x1F, name="Hologuise",       req_items={{0x1E,0x02,0x0C,0x1D}, {0x1E,0x03,0x0C,0x1D}} },
-  {id=0x20, name="PDA",             req_items={{0x1C}} },
-  {id=0x21, name="Map-O-Matic",     req_items={{0x1D}} },
-  {id=0x22, name="Bolt Grabber",    req_items={{0x04,0x06}} },
-  {id=0x23, name="Persuader",       req_items={{0x1A,0x31,0x16}} },
-  {id=0x30, name="Zoomerator",      req_items={{0x1E,0x02}, {0x1E,0x03}} },
-  {id=0x31, name="Raritanium",      req_items={{0x0C,0x02}, {0x0C,0x03}} },
-  {id=0x32, name="Codebot",         req_items={{0x04,0x06}} },
-  {id=0x34, name="Premium Nanotech",req_items={{0x06,0x02}, {0x06,0x03}} },
-  {id=0x35, name="Ultra Nanotech",  req_items={{0x06,0x03,0x34,0x1B}, {0x06,0x02,0x34,0x1B} }},
+  {id=0x1F, name="Hologuise",       req_items={{keyid.hoverboard,keyid.heli_pack,keyid.swingshot,keyid.grindboots}, {keyid.hoverboard,keyid.thruster_pack,keyid.swingshot,keyid.grindboots}} },
+  {id=0x20, name="PDA",             req_items={{keyid.magneboots}} },
+  {id=0x21, name="Map-O-Matic",     req_items={{keyid.grindboots}} },
+  {id=0x22, name="Bolt Grabber",    req_items={{keyid.hydro_pack,keyid.o2_mask}} },
+  {id=0x23, name="Persuader",       req_items={{keyid.trespasser,keyid.raritanium,keyid.hydrodisplacer}} },
+  {id=0x30, name="Zoomerator",      req_items={{keyid.hoverboard,keyid.heli_pack}, {keyid.hoverboard,keyid.thruster_pack}} },
+  {id=0x31, name="Raritanium",      req_items={{keyid.swingshot,keyid.heli_pack}, {keyid.swingshot,keyid.thruster_pack}} },
+  {id=0x32, name="Codebot",         req_items={{keyid.hydro_pack,keyid.o2_mask}} },
+  {id=0x34, name="Premium Nanotech",req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}} },
+  {id=0x35, name="Ultra Nanotech",  req_items={{keyid.o2_mask,keyid.thruster_pack,keyid.premium_nanotech,keyid.metal_detector}, {keyid.o2_mask,keyid.heli_pack,keyid.premium_nanotech,keyid.metal_detector} }},
 }
 
 infobots = {
   {id=0x01, req_items={} },                                 -- Veldin1 -> Novalis
   {id=0x02, req_items={} },                                 -- Novalis -> Aridia
   {id=0x03, req_items={} },                                 -- Novalis -> Kerwan
-  {id=0x04, req_items={{0x02}, {0x03}} },                   -- Kerwan -> Eudora
+  {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} },                   -- Kerwan -> Eudora
   {id=0x05, req_items={} },                                 -- Blarg -> Rilgar
-  {id=0x06, req_items={{0x1A,0x0C,0x02}, {0x1A,0x0C,0x03}} }, -- Eudora -> Blarg
-  {id=0x07, req_items={{0x0C,0x16}} },                      -- Rilgar -> Umbris
-  {id=0x08, req_items={{0x0C,0x16}} },                      -- Umbris -> Batalia
-  {id=0x09, req_items={{0x1D}} },                           -- Batalia -> Gaspar
+  {id=0x06, req_items={{keyid.trespasser,keyid.swingshot,keyid.heli_pack}, {keyid.trespasser,keyid.swingshot,keyid.thruster_pack}} }, -- Eudora -> Blarg
+  {id=0x07, req_items={{keyid.swingshot,keyid.hydrodisplacer}} },                      -- Rilgar -> Umbris
+  {id=0x08, req_items={{keyid.swingshot,keyid.hydrodisplacer}} },                      -- Umbris -> Batalia
+  {id=0x09, req_items={{keyid.grindboots}} },                           -- Batalia -> Gaspar
   {id=0x0A, req_items={} },                                 -- Batalia -> Orxon
   {id=0x0B, req_items={} },                                 -- Orxon -> Pokitaru
-  {id=0x0C, req_items={{0x06,0x0C,0x1C,0x03}} },            -- Orxon -> Hoven
+  {id=0x0C, req_items={{keyid.o2_mask,keyid.swingshot,keyid.magneboots,keyid.thruster_pack}} },            -- Orxon -> Hoven
   {id=0x0D, req_items={} },                                 -- Hoven -> Gemlik
-  {id=0x0E, req_items={{0x0C, 0x1C, 0x1A, 0x0B}, {0x0C, 0x1C, 0x1A, 0x0D}} },         -- Gemlik -> Oltanis
-  {id=0x0F, req_items={{0x1D}} },                           -- Oltanis -> Quartu
-  {id=0x10, req_items={{0x0C}} },                           -- Quartu -> KaleboIII
-  {id=0x11, req_items={{0x03,0x0C,0x1F}} },                 -- Quartu -> Fleet
-  {id=0x12, req_items={{0x1C,0x1F}} }                       -- Fleet -> Veldin2
+  {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.swingshot, keyid.magneboots,keyid.trespasser, keyid.visibomb}} },         -- Gemlik -> Oltanis
+  {id=0x0F, req_items={{keyid.grindboots}} },                           -- Oltanis -> Quartu
+  {id=0x10, req_items={{keyid.swingshot}} },                           -- Quartu -> KaleboIII
+  {id=0x11, req_items={{0x03,keyid.swingshot,keyid.hologuise}} },                 -- Quartu -> Fleet
+  {id=0x12, req_items={{keyid.magneboots,keyid.hologuise}} }                       -- Fleet -> Veldin2
 }
 
 planets = {
-  {id=1,  name="Novalis",  infobots={0x02,0x03},  items={0x10} },
-  {id=2,  name="Aridia",   infobots={},           items={0x1E,0x1A,0x05} },
-  {id=3,  name="Kerwan",   infobots={0x04},       items={0x0C,0x02,0x0F} },
-  {id=4,  name="Eudora",   infobots={0x06},       items={0x14,0x09} },
-  {id=5,  name="Rilgar",   infobots={0x07},       items={0x30,0x11,0x17} },
-  {id=6,  name="Blarg",    infobots={0x05},       items={0x1D,0x16,0x0E} },
-  {id=7,  name="Umbris",   infobots={0x08},       items={} },
-  {id=8,  name="Batalia",  infobots={0x09,0x0A},  items={0x1B,0x0B} },
-  {id=9,  name="Gaspar",   infobots={},           items={0x07,0x12} },
-  {id=10, name="Orxon",    infobots={0x0B,0x0C},  items={0x34,0x35,0x1C,0x0D} },
-  {id=11, name="Pokitaru", infobots={},           items={0x03,0x06,0x23,0x19} },
-  {id=12, name="Hoven",    infobots={0x0D},       items={0x31,0x04,0x18} },
-  {id=13, name="Gemlik",   infobots={0x0E},       items={} },
-  {id=14, name="Oltanis",  infobots={0x0F},       items={0x20,0x13,0x15} },
-  {id=15, name="Quartu",   infobots={0x10,0x11},  items={0x22} },
-  {id=16, name="KaleboIII",infobots={},           items={0x1F,0x21} },
-  {id=17, name="Fleet",    infobots={0x12},       items={0x32} }
+  {id=1,  name="Novalis",  infobots={keyid.aridia,keyid.kerwan},  items={keyid.pyrociter} },
+  {id=2,  name="Aridia",   infobots={},                           items={keyid.hoverboard,keyid.trespasser,keyid.sonic_summoner} },
+  {id=3,  name="Kerwan",   infobots={keyid.eudora},               items={keyid.swingshot,keyid.heli_pack,keyid.blaster} },
+  {id=4,  name="Eudora",   infobots={keyid.blarg},                items={keyid.glove_of_doom,keyid.suck_cannon} },
+  {id=5,  name="Rilgar",   infobots={keyid.umbris},               items={keyid.zoomerator,keyid.mine_glove,keyid.ryno} },
+  {id=6,  name="Blarg",    infobots={keyid.rilgar},               items={keyid.grindboots,keyid.hydrodisplacer,keyid.taunter} },
+  {id=7,  name="Umbris",   infobots={keyid.batalia},              items={} },
+  {id=8,  name="Batalia",  infobots={keyid.gaspar,keyid.orxon},   items={keyid.metal_detector,keyid.devastator} },
+  {id=9,  name="Gaspar",   infobots={},                           items={keyid.pilots_helmet,keyid.walloper} },
+  {id=10, name="Orxon",    infobots={keyid.pokitaru,keyid.hoven}, items={keyid.premium_nanotech,keyid.ultra_nanotech,keyid.magneboots,keyid.visibomb} },
+  {id=11, name="Pokitaru", infobots={},                           items={keyid.thruster_pack,keyid.o2_mask,keyid.persuader,keyid.decoy_glove} },
+  {id=12, name="Hoven",    infobots={keyid.gemlik},               items={keyid.raritanium,keyid.hydro_pack,keyid.drone_device} },
+  {id=13, name="Gemlik",   infobots={keyid.oltanis},              items={} },
+  {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.PDA,keyid.tesla_claw,keyid.morph_o_ray} },
+  {id=15, name="Quartu",   infobots={keyid.kalebo,keyid.fleet},   items={keyid.bolt_grabber} },
+  {id=16, name="KaleboIII",infobots={},                           items={keyid.hologuise,keyid.map_o_matic} },
+  {id=17, name="Fleet",    infobots={keyid.veldin},               items={keyid.codebot} }
 }

--- a/logic1_Speed.lua
+++ b/logic1_Speed.lua
@@ -1,11 +1,13 @@
+require 'table_id'
+
 items = {
     {id=0x02, name="Heli-pack",       req_items={} },
     {id=0x03, name="Thruster-pack",   req_items={} },
-    {id=0x04, name="Hydro-pack",      req_items={{0x16}, {0x02}, {0x03}, {0x20}} },
-    {id=0x05, name="Sonic Summoner",  req_items={{0x30}} },
-    {id=0x06, name="O2 Mask",         req_items={{0x07}} },
+    {id=0x04, name="Hydro-pack",      req_items={{keyid.hydrodisplacer}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
+    {id=0x05, name="Sonic Summoner",  req_items={{keyid.zoomerator}} },
+    {id=0x06, name="O2 Mask",         req_items={{keyid.pilots_helmet}} },
     {id=0x07, name="Pilot's Helmet",  req_items={} },
-    {id=0x09, name="Suck Cannon",     req_items={{0x02}, {0x03}, {0x20}} },
+    {id=0x09, name="Suck Cannon",     req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x0B, name="Devastator",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x0C, name="Swingshot",       req_items={} },
     {id=0x0D, name="Visibomb",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
@@ -16,65 +18,65 @@ items = {
     {id=0x12, name="Walloper",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x13, name="Tesla Claw",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x14, name="Glove of Doom",   req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x15, name="Morph-O-Ray",     req_items={{0x0C}, {0x20}} },
-    {id=0x16, name="Hydrodisplacer",  req_items={{0x1A}, {0x02}, {0x03}, {0x20}} },
-    {id=0x17, name="R.Y.N.O.",        req_items={{0x1B,0x02}, {0x1B,0x03}, {0x1B,0x20}} },
+    {id=0x15, name="Morph-O-Ray",     req_items={{keyid.swingshot}, {keyid.pda}} },
+    {id=0x16, name="Hydrodisplacer",  req_items={{keyid.trespasser}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
+    {id=0x17, name="R.Y.N.O.",        req_items={{keyid.metal_detector,keyid.heli_pack}, {keyid.metal_detector,keyid.thruster_pack}, {keyid.metal_detector,keyid.pda}} },
     {id=0x18, name="Drone Device",    req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x19, name="Decoy Glove",     req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x1A, name="Trespasser",      req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },
-    {id=0x1B, name="MetalDetector",   req_items={{0x1C}, {0x02}, {0x03}, {0x20}} },
+    {id=0x1A, name="Trespasser",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
+    {id=0x1B, name="MetalDetector",   req_items={{keyid.magneboots}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x1C, name="Magneboots",      req_items={} },
-    {id=0x1D, name="Grindboots",      req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },
+    {id=0x1D, name="Grindboots",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x1E, name="Hoverboard",      req_items={} },
-    {id=0x1F, name="Hologuise",       req_items={{0x1E,0x02}, {0x1E,0x0D}, {0x1E,0x19}, {0x03}, {0x20}} },
-    {id=0x20, name="PDA",             req_items={{0x1C}} },
-    {id=0x21, name="Map-O-Matic",     req_items={{0x1D}, {0x20}} },
-    {id=0x22, name="Bolt Grabber",    req_items={{0x04,0x06}, {0x20}, {0x02}, {0x03}} },
-    {id=0x23, name="Persuader",       req_items={{0x31,0x1A,0x16}, {0x31,0x06}} },
-    {id=0x30, name="Zoomerator",      req_items={{0x02}, {0x03}, {0x20}} },
-    {id=0x31, name="Raritanium",      req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },
+    {id=0x1F, name="Hologuise",       req_items={{keyid.hoverboard,keyid.heli_pack}, {keyid.hoverboard,keyid.visibomb}, {keyid.hoverboard,keyid.decoy_glove}, {keyid.thruster_pack}, {keyid.pda}} },
+    {id=0x20, name="PDA",             req_items={{keyid.magneboots}} },
+    {id=0x21, name="Map-O-Matic",     req_items={{keyid.grindboots}, {keyid.pda}} },
+    {id=0x22, name="Bolt Grabber",    req_items={{keyid.hydro_pack,keyid.o2_mask}, {keyid.pda}, {keyid.heli_pack}, {keyid.thruster_pack}} },
+    {id=0x23, name="Persuader",       req_items={{keyid.raritanium,keyid.trespasser,keyid.hydrodisplacer}, {keyid.raritanium,keyid.o2_mask}} },
+    {id=0x30, name="Zoomerator",      req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
+    {id=0x31, name="Raritanium",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x32, name="Codebot",         req_items={} },
-    {id=0x34, name="Premium Nanotech",req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },
-    {id=0x35, name="Ultra Nanotech",  req_items={{0x34,0x06,0x02}, {0x34,0x06,0x03}, {0x34,0x06,0x20}} },
+    {id=0x34, name="Premium Nanotech",req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}, {keyid.o2_mask,keyid.pda}} },
+    {id=0x35, name="Ultra Nanotech",  req_items={{keyid.premium_nanotech,keyid.o2_mask,keyid.heli_pack}, {keyid.premium_nanotech,keyid.o2_mask,keyid.thruster_pack}, {keyid.premium_nanotech,keyid.o2_mask,keyid.pda}} },
 }
 
 infobots = {
     {id=0x01, req_items={} },				                        -- Veldin1 -> Novalis
     {id=0x02, req_items={} },				                        -- Novalis -> Aridia
     {id=0x03, req_items={} },				                        -- Novalis -> Kerwan
-    {id=0x04, req_items={{0x02}, {0x03}, {0x20}} },         -- Kerwan -> Eudora
+    {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },         -- Kerwan -> Eudora
     {id=0x05, req_items={} },				                        -- Blarg -> Rilgar
-    {id=0x06, req_items={{0x02}, {0x03}, {0x20}, {0x19}} }, -- Eudora -> Blarg
-    {id=0x07, req_items={{0x02}, {0x03}, {0x20}, {0x0C}} }, -- Rilgar -> Umbris
-    {id=0x08, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} }, -- Umbris -> Batalia
-    {id=0x09, req_items={{0x1D}, {0x02}, {0x20}} },         -- Batalia -> Gaspar
+    {id=0x06, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}, {keyid.decoy_glove}} }, -- Eudora -> Blarg
+    {id=0x07, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}, {keyid.swingshot}} }, -- Rilgar -> Umbris
+    {id=0x08, req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Umbris -> Batalia
+    {id=0x09, req_items={{keyid.grindboots}, {keyid.heli_pack}, {keyid.pda}} },         -- Batalia -> Gaspar
     {id=0x0A, req_items={} },				                        -- Batalia -> Orxon
     {id=0x0B, req_items={} },				                        -- Orxon -> Pokitaru
-    {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },         -- Orxon -> Hoven
+    {id=0x0C, req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}, {keyid.o2_mask,keyid.pda}} },         -- Orxon -> Hoven
     {id=0x0D, req_items={} },				                                       -- Hoven -> Gemlik
-    {id=0x0E, req_items={{0x0C,0x1C,0x1A,0x0B}, {0x02}, {0x03}, {0x20}} }, -- Gemlik -> Oltanis
-    {id=0x0F, req_items={{0x1D}, {0x1C}, {0x20}} },         -- Oltanis -> Quartu
-    {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} }, -- Quartu -> KaleboIII
-    {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },         -- Quartu -> Fleet
-    {id=0x12, req_items={{0x03}, {0x1C}, {0x19}, {0x20}} }  -- Fleet -> Veldin2
+    {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Gemlik -> Oltanis
+    {id=0x0F, req_items={{keyid.grindboots}, {keyid.magneboots}, {keyid.pda}} },         -- Oltanis -> Quartu
+    {id=0x10, req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Quartu -> KaleboIII
+    {id=0x11, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },         -- Quartu -> Fleet
+    {id=0x12, req_items={{keyid.thruster_pack}, {keyid.magneboots}, {keyid.decoy_glove}, {keyid.pda}} }  -- Fleet -> Veldin2
 }
 
 planets = {
-    {id=1,  name="Novalis",  infobots={0x02,0x03},  items={0x10} },
-    {id=2,  name="Aridia",   infobots={},           items={0x1E,0x1A,0x05} },
-    {id=3,  name="Kerwan",   infobots={0x04},       items={0x0C,0x02,0x0F} },
-    {id=4,  name="Eudora",   infobots={0x06},       items={0x14,0x09} },
-    {id=5,  name="Rilgar",   infobots={0x07},       items={0x30,0x11,0x17} },
-    {id=6,  name="Blarg",    infobots={0x05},       items={0x1D,0x16,0x0E} },
-    {id=7,  name="Umbris",   infobots={0x08},       items={} },
-    {id=8,  name="Batalia",  infobots={0x09,0x0A},  items={0x1B,0x0B} },
-    {id=9,  name="Gaspar",   infobots={},           items={0x07,0x12} },
-    {id=10, name="Orxon",    infobots={0x0B,0x0C},  items={0x34,0x35,0x1C,0x0D} },
-    {id=11, name="Pokitaru", infobots={},           items={0x03,0x06,0x23,0x19} },
-    {id=12, name="Hoven",    infobots={0x0D},       items={0x31,0x04,0x18} },
-    {id=13, name="Gemlik",   infobots={0x0E},       items={} },
-    {id=14, name="Oltanis",  infobots={0x0F},       items={0x20,0x13,0x15} },
-    {id=15, name="Quartu",   infobots={0x10,0x11},  items={0x22} },
-    {id=16, name="KaleboIII",infobots={},           items={0x1F,0x21} },
-    {id=17, name="Fleet",    infobots={0x12},       items={0x32} }
+    {id=1,  name="Novalis",  infobots={keyid.aridia,keyid.kerwan},  items={keyid.pyrociter} },
+    {id=2,  name="Aridia",   infobots={},                           items={keyid.hoverboard,keyid.trespasser,keyid.sonic_summoner} },
+    {id=3,  name="Kerwan",   infobots={keyid.eudora},               items={keyid.swingshot,keyid.heli_pack,keyid.blaster} },
+    {id=4,  name="Eudora",   infobots={keyid.blarg},                items={keyid.glove_of_doom,keyid.suck_cannon} },
+    {id=5,  name="Rilgar",   infobots={keyid.umbris},               items={keyid.zoomerator,keyid.mine_glove,keyid.ryno} },
+    {id=6,  name="Blarg",    infobots={keyid.rilgar},               items={keyid.grindboots,keyid.hydrodisplacer,keyid.taunter} },
+    {id=7,  name="Umbris",   infobots={keyid.batalia},              items={} },
+    {id=8,  name="Batalia",  infobots={keyid.gaspar,keyid.orxon},   items={keyid.metal_detector,keyid.devastator} },
+    {id=9,  name="Gaspar",   infobots={},                           items={keyid.pilots_helmet,keyid.walloper} },
+    {id=10, name="Orxon",    infobots={keyid.pokitaru,keyid.hoven}, items={keyid.premium_nanotech,keyid.ultra_nanotech,keyid.magneboots,keyid.visibomb} },
+    {id=11, name="Pokitaru", infobots={},                           items={keyid.thruster_pack,keyid.o2_mask,keyid.persuader,keyid.decoy_glove} },
+    {id=12, name="Hoven",    infobots={keyid.gemlik},               items={keyid.raritanium,keyid.hydro_pack,keyid.drone_device} },
+    {id=13, name="Gemlik",   infobots={keyid.oltanis},              items={} },
+    {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.PDA,keyid.tesla_claw,keyid.morph_o_ray} },
+    {id=15, name="Quartu",   infobots={keyid.kalebo,keyid.fleet},   items={keyid.bolt_grabber} },
+    {id=16, name="KaleboIII",infobots={},                           items={keyid.hologuise,keyid.map_o_matic} },
+    {id=17, name="Fleet",    infobots={keyid.veldin},               items={keyid.codebot} }
 }

--- a/logic1_Speed.lua
+++ b/logic1_Speed.lua
@@ -41,24 +41,24 @@ items = {
 }
 
 infobots = {
-    {id=0x01, req_items={} },				                        -- Veldin1 -> Novalis
-    {id=0x02, req_items={} },				                        -- Novalis -> Aridia
-    {id=0x03, req_items={} },				                        -- Novalis -> Kerwan
-    {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },         -- Kerwan -> Eudora
-    {id=0x05, req_items={} },				                        -- Blarg -> Rilgar
+    {id=0x01, req_items={} }, -- Veldin1 -> Novalis
+    {id=0x02, req_items={} }, -- Novalis -> Aridia
+    {id=0x03, req_items={} }, -- Novalis -> Kerwan
+    {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Kerwan -> Eudora
+    {id=0x05, req_items={} }, -- Blarg -> Rilgar
     {id=0x06, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}, {keyid.decoy_glove}} }, -- Eudora -> Blarg
     {id=0x07, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}, {keyid.swingshot}} }, -- Rilgar -> Umbris
     {id=0x08, req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Umbris -> Batalia
-    {id=0x09, req_items={{keyid.grindboots}, {keyid.heli_pack}, {keyid.pda}} },         -- Batalia -> Gaspar
-    {id=0x0A, req_items={} },				                        -- Batalia -> Orxon
-    {id=0x0B, req_items={} },				                        -- Orxon -> Pokitaru
-    {id=0x0C, req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}, {keyid.o2_mask,keyid.pda}} },         -- Orxon -> Hoven
-    {id=0x0D, req_items={} },				                                       -- Hoven -> Gemlik
+    {id=0x09, req_items={{keyid.grindboots}, {keyid.heli_pack}, {keyid.pda}} }, -- Batalia -> Gaspar
+    {id=0x0A, req_items={} }, -- Batalia -> Orxon
+    {id=0x0B, req_items={} }, -- Orxon -> Pokitaru
+    {id=0x0C, req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}, {keyid.o2_mask,keyid.pda}} }, -- Orxon -> Hoven
+    {id=0x0D, req_items={} }, -- Hoven -> Gemlik
     {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Gemlik -> Oltanis
-    {id=0x0F, req_items={{keyid.grindboots}, {keyid.magneboots}, {keyid.pda}} },         -- Oltanis -> Quartu
+    {id=0x0F, req_items={{keyid.grindboots}, {keyid.magneboots}, {keyid.pda}} }, -- Oltanis -> Quartu
     {id=0x10, req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Quartu -> KaleboIII
-    {id=0x11, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },         -- Quartu -> Fleet
-    {id=0x12, req_items={{keyid.thruster_pack}, {keyid.magneboots}, {keyid.decoy_glove}, {keyid.pda}} }  -- Fleet -> Veldin2
+    {id=0x11, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Quartu -> Fleet
+    {id=0x12, req_items={{keyid.thruster_pack}, {keyid.magneboots}, {keyid.decoy_glove}, {keyid.pda}} } -- Fleet -> Veldin2
 }
 
 planets = {
@@ -75,7 +75,7 @@ planets = {
     {id=11, name="Pokitaru", infobots={},                           items={keyid.thruster_pack,keyid.o2_mask,keyid.persuader,keyid.decoy_glove} },
     {id=12, name="Hoven",    infobots={keyid.gemlik},               items={keyid.raritanium,keyid.hydro_pack,keyid.drone_device} },
     {id=13, name="Gemlik",   infobots={keyid.oltanis},              items={} },
-    {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.PDA,keyid.tesla_claw,keyid.morph_o_ray} },
+    {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.pda,keyid.tesla_claw,keyid.morph_o_ray} },
     {id=15, name="Quartu",   infobots={keyid.kalebo,keyid.fleet},   items={keyid.bolt_grabber} },
     {id=16, name="KaleboIII",infobots={},                           items={keyid.hologuise,keyid.map_o_matic} },
     {id=17, name="Fleet",    infobots={keyid.veldin},               items={keyid.codebot} }

--- a/logic2_Custom.lua
+++ b/logic2_Custom.lua
@@ -2,15 +2,16 @@
 Customized by Alados5 (Jun'22)
 Basically removed Batalia SI, ILJ/ISF ship to boss on Umbris, and a couple clips
 --]]
+require 'table_id'
 
 items = {
     {id=0x02, name="Heli-pack",       req_items={} },
     {id=0x03, name="Thruster-pack",   req_items={} },
-    {id=0x04, name="Hydro-pack",      req_items={{0x16}, {0x02}, {0x03}} },
-    {id=0x05, name="Sonic Summoner",  req_items={{0x30}} },
-    {id=0x06, name="O2 Mask",         req_items={{0x07}} },
+    {id=0x04, name="Hydro-pack",      req_items={{keyid.hydrodisplacer}, {keyid.heli_pack}, {keyid.thruster_pack}} },
+    {id=0x05, name="Sonic Summoner",  req_items={{keyid.zoomerator}} },
+    {id=0x06, name="O2 Mask",         req_items={{keyid.pilots_helmet}} },
     {id=0x07, name="Pilot's Helmet",  req_items={} },
-    {id=0x09, name="Suck Cannon",     req_items={{0x02}, {0x03}, {0x20}} },
+    {id=0x09, name="Suck Cannon",     req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },
     {id=0x0B, name="Devastator",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x0C, name="Swingshot",       req_items={} },
     {id=0x0D, name="Visibomb",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
@@ -21,65 +22,65 @@ items = {
     {id=0x12, name="Walloper",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x13, name="Tesla Claw",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x14, name="Glove of Doom",   req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x15, name="Morph-O-Ray",     req_items={{0x0C}, {0x20}} },
-    {id=0x16, name="Hydrodisplacer",  req_items={{0x1A}, {0x02}, {0x03}, {0x20}} },
-    {id=0x17, name="R.Y.N.O.",        req_items={{0x1B,0x02}, {0x1B,0x03}} },
+    {id=0x15, name="Morph-O-Ray",     req_items={{keyid.swingshot}, {keyid.PDA}} },
+    {id=0x16, name="Hydrodisplacer",  req_items={{keyid.trespasser}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },
+    {id=0x17, name="R.Y.N.O.",        req_items={{keyid.metal_detector,keyid.heli_pack}, {keyid.metal_detector,keyid.thruster_pack}} },
     {id=0x18, name="Drone Device",    req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x19, name="Decoy Glove",     req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x1A, name="Trespasser",      req_items={{0x0C}, {0x02}, {0x03}} },
-    {id=0x1B, name="MetalDetector",   req_items={{0x1C}, {0x02}, {0x03}} },
+    {id=0x1A, name="Trespasser",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}} },
+    {id=0x1B, name="MetalDetector",   req_items={{keyid.magneboots}, {keyid.heli_pack}, {keyid.thruster_pack}} },
     {id=0x1C, name="Magneboots",      req_items={} },
-    {id=0x1D, name="Grindboots",      req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },
+    {id=0x1D, name="Grindboots",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },
     {id=0x1E, name="Hoverboard",      req_items={} },
-    {id=0x1F, name="Hologuise",       req_items={{0x1E,0x02}, {0x1E,0x0D}, {0x03}, {0x20}} },
-    {id=0x20, name="PDA",             req_items={{0x1C}} },
-    {id=0x21, name="Map-O-Matic",     req_items={{0x1D}, {0x20,0x03}} },
-    {id=0x22, name="Bolt Grabber",    req_items={{0x04,0x06}, {0x20}} },
-    {id=0x23, name="Persuader",       req_items={{0x31,0x1A,0x16}, {0x31,0x06}} },
-    {id=0x30, name="Zoomerator",      req_items={{0x02}, {0x03}, {0x20}} },
-    {id=0x31, name="Raritanium",      req_items={{0x0C}, {0x02}, {0x03}} },
+    {id=0x1F, name="Hologuise",       req_items={{keyid.hoverboard,keyid.heli_pack}, {keyid.hoverboard,keyid.visibomb}, {keyid.thruster_pack}, {keyid.PDA}} },
+    {id=0x20, name="PDA",             req_items={{keyid.magneboots}} },
+    {id=0x21, name="Map-O-Matic",     req_items={{keyid.grindboots}, {keyid.PDA,keyid.thruster_pack}} },
+    {id=0x22, name="Bolt Grabber",    req_items={{keyid.hydro_pack,keyid.o2_mask}, {keyid.PDA}} },
+    {id=0x23, name="Persuader",       req_items={{keyid.raritanium,keyid.trespasser,keyid.hydrodisplacer}, {keyid.raritanium,keyid.o2_mask}} },
+    {id=0x30, name="Zoomerator",      req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },
+    {id=0x31, name="Raritanium",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}} },
     {id=0x32, name="Codebot",         req_items={} },
-    {id=0x34, name="Premium Nanotech",req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },
-    {id=0x35, name="Ultra Nanotech",  req_items={{0x34,0x06,0x02}, {0x34,0x06,0x03}, {0x34,0x06,0x20}} },
+    {id=0x34, name="Premium Nanotech",req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}, {keyid.o2_mask,keyid.PDA}} },
+    {id=0x35, name="Ultra Nanotech",  req_items={{keyid.premium_nanotech,keyid.o2_mask,keyid.heli_pack}, {keyid.premium_nanotech,keyid.o2_mask,keyid.thruster_pack}, {keyid.premium_nanotech,keyid.o2_mask,keyid.PDA}} },
 }
 
 infobots = {
     {id=0x01, req_items={} },				                             -- Veldin1 -> Novalis
     {id=0x02, req_items={} },				                             -- Novalis -> Aridia
     {id=0x03, req_items={} },				                             -- Novalis -> Kerwan
-    {id=0x04, req_items={{0x02}, {0x03}} },                      -- Kerwan -> Eudora
+    {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} },                      -- Kerwan -> Eudora
     {id=0x05, req_items={} },				                             -- Blarg -> Rilgar
-    {id=0x06, req_items={{0x02}, {0x03}, {0x19}} },              -- Eudora -> Blarg
-    {id=0x07, req_items={{0x02}, {0x03}} },                      -- Rilgar -> Umbris
-    {id=0x08, req_items={{0x0C,0x02}, {0x0C,0x03}} },            -- Umbris -> Batalia
-    {id=0x09, req_items={{0x1D}, {0x02,0x20}, {0x03,0x20}} },    -- Batalia -> Gaspar
+    {id=0x06, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.decoy_glove}} },              -- Eudora -> Blarg
+    {id=0x07, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} },                      -- Rilgar -> Umbris
+    {id=0x08, req_items={{keyid.swingshot,keyid.heli_pack}, {keyid.swingshot,keyid.thruster_pack}} },            -- Umbris -> Batalia
+    {id=0x09, req_items={{keyid.grindboots}, {keyid.heli_pack,keyid.PDA}, {keyid.thruster_pack,keyid.PDA}} },    -- Batalia -> Gaspar
     {id=0x0A, req_items={} },				                             -- Batalia -> Orxon
     {id=0x0B, req_items={} },				                             -- Orxon -> Pokitaru
-    {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}} },            -- Orxon -> Hoven
+    {id=0x0C, req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}} },            -- Orxon -> Hoven
     {id=0x0D, req_items={} },				                                       -- Hoven -> Gemlik
-    {id=0x0E, req_items={{0x0C,0x1C,0x1A,0x0B}, {0x02}, {0x03}, {0x20}} }, -- Gemlik -> Oltanis
-    {id=0x0F, req_items={{0x1D}, {0x20}} },                      -- Oltanis -> Quartu
-    {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },      -- Quartu -> KaleboIII
-    {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },              -- Quartu -> Fleet
-    {id=0x12, req_items={{0x03}, {0x1C}, {0x19}} }               -- Fleet -> Veldin2
+    {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} }, -- Gemlik -> Oltanis
+    {id=0x0F, req_items={{keyid.grindboots}, {keyid.PDA}} },                      -- Oltanis -> Quartu
+    {id=0x10, req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },      -- Quartu -> KaleboIII
+    {id=0x11, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },              -- Quartu -> Fleet
+    {id=0x12, req_items={{keyid.thruster_pack}, {keyid.magneboots}, {keyid.decoy_glove}} }               -- Fleet -> Veldin2
 }
 
 planets = {
-    {id=1,  name="Novalis",  infobots={0x02,0x03},  items={0x10} },
-    {id=2,  name="Aridia",   infobots={},           items={0x1E,0x1A,0x05} },
-    {id=3,  name="Kerwan",   infobots={0x04},       items={0x0C,0x02,0x0F} },
-    {id=4,  name="Eudora",   infobots={0x06},       items={0x14,0x09} },
-    {id=5,  name="Rilgar",   infobots={0x07},       items={0x30,0x11,0x17} },
-    {id=6,  name="Blarg",    infobots={0x05},       items={0x1D,0x16,0x0E} },
-    {id=7,  name="Umbris",   infobots={0x08},       items={} },
-    {id=8,  name="Batalia",  infobots={0x09,0x0A},  items={0x1B,0x0B} },
-    {id=9,  name="Gaspar",   infobots={},           items={0x07,0x12} },
-    {id=10, name="Orxon",    infobots={0x0B,0x0C},  items={0x34,0x35,0x1C,0x0D} },
-    {id=11, name="Pokitaru", infobots={},           items={0x03,0x06,0x23,0x19} },
-    {id=12, name="Hoven",    infobots={0x0D},       items={0x31,0x04,0x18} },
-    {id=13, name="Gemlik",   infobots={0x0E},       items={} },
-    {id=14, name="Oltanis",  infobots={0x0F},       items={0x20,0x13,0x15} },
-    {id=15, name="Quartu",   infobots={0x10,0x11},  items={0x22} },
-    {id=16, name="KaleboIII",infobots={},           items={0x1F,0x21} },
-    {id=17, name="Fleet",    infobots={0x12},       items={0x32} }
+    {id=1,  name="Novalis",  infobots={keyid.aridia,keyid.kerwan},  items={keyid.pyrociter} },
+    {id=2,  name="Aridia",   infobots={},                           items={keyid.hoverboard,keyid.trespasser,keyid.sonic_summoner} },
+    {id=3,  name="Kerwan",   infobots={keyid.eudora},               items={keyid.swingshot,keyid.heli_pack,keyid.blaster} },
+    {id=4,  name="Eudora",   infobots={keyid.blarg},                items={keyid.glove_of_doom,keyid.suck_cannon} },
+    {id=5,  name="Rilgar",   infobots={keyid.umbris},               items={keyid.zoomerator,keyid.mine_glove,keyid.ryno} },
+    {id=6,  name="Blarg",    infobots={keyid.rilgar},               items={keyid.grindboots,keyid.hydrodisplacer,keyid.taunter} },
+    {id=7,  name="Umbris",   infobots={keyid.batalia},              items={} },
+    {id=8,  name="Batalia",  infobots={keyid.gaspar,keyid.orxon},   items={keyid.metal_detector,keyid.devastator} },
+    {id=9,  name="Gaspar",   infobots={},                           items={keyid.pilots_helmet,keyid.walloper} },
+    {id=10, name="Orxon",    infobots={keyid.pokitaru,keyid.hoven}, items={keyid.premium_nanotech,keyid.ultra_nanotech,keyid.magneboots,keyid.visibomb} },
+    {id=11, name="Pokitaru", infobots={},                           items={keyid.thruster_pack,keyid.o2_mask,keyid.persuader,keyid.decoy_glove} },
+    {id=12, name="Hoven",    infobots={keyid.gemlik},               items={keyid.raritanium,keyid.hydro_pack,keyid.drone_device} },
+    {id=13, name="Gemlik",   infobots={keyid.oltanis},              items={} },
+    {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.PDA,keyid.tesla_claw,keyid.morph_o_ray} },
+    {id=15, name="Quartu",   infobots={keyid.kalebo,keyid.fleet},   items={keyid.bolt_grabber} },
+    {id=16, name="KaleboIII",infobots={},                           items={keyid.hologuise,keyid.map_o_matic} },
+    {id=17, name="Fleet",    infobots={keyid.veldin},               items={keyid.codebot} }
 }

--- a/logic2_Custom.lua
+++ b/logic2_Custom.lua
@@ -11,7 +11,7 @@ items = {
     {id=0x05, name="Sonic Summoner",  req_items={{keyid.zoomerator}} },
     {id=0x06, name="O2 Mask",         req_items={{keyid.pilots_helmet}} },
     {id=0x07, name="Pilot's Helmet",  req_items={} },
-    {id=0x09, name="Suck Cannon",     req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },
+    {id=0x09, name="Suck Cannon",     req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x0B, name="Devastator",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x0C, name="Swingshot",       req_items={} },
     {id=0x0D, name="Visibomb",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
@@ -22,47 +22,47 @@ items = {
     {id=0x12, name="Walloper",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x13, name="Tesla Claw",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x14, name="Glove of Doom",   req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x15, name="Morph-O-Ray",     req_items={{keyid.swingshot}, {keyid.PDA}} },
-    {id=0x16, name="Hydrodisplacer",  req_items={{keyid.trespasser}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },
+    {id=0x15, name="Morph-O-Ray",     req_items={{keyid.swingshot}, {keyid.pda}} },
+    {id=0x16, name="Hydrodisplacer",  req_items={{keyid.trespasser}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x17, name="R.Y.N.O.",        req_items={{keyid.metal_detector,keyid.heli_pack}, {keyid.metal_detector,keyid.thruster_pack}} },
     {id=0x18, name="Drone Device",    req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x19, name="Decoy Glove",     req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
     {id=0x1A, name="Trespasser",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}} },
     {id=0x1B, name="MetalDetector",   req_items={{keyid.magneboots}, {keyid.heli_pack}, {keyid.thruster_pack}} },
     {id=0x1C, name="Magneboots",      req_items={} },
-    {id=0x1D, name="Grindboots",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },
+    {id=0x1D, name="Grindboots",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x1E, name="Hoverboard",      req_items={} },
-    {id=0x1F, name="Hologuise",       req_items={{keyid.hoverboard,keyid.heli_pack}, {keyid.hoverboard,keyid.visibomb}, {keyid.thruster_pack}, {keyid.PDA}} },
+    {id=0x1F, name="Hologuise",       req_items={{keyid.hoverboard,keyid.heli_pack}, {keyid.hoverboard,keyid.visibomb}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x20, name="PDA",             req_items={{keyid.magneboots}} },
-    {id=0x21, name="Map-O-Matic",     req_items={{keyid.grindboots}, {keyid.PDA,keyid.thruster_pack}} },
-    {id=0x22, name="Bolt Grabber",    req_items={{keyid.hydro_pack,keyid.o2_mask}, {keyid.PDA}} },
+    {id=0x21, name="Map-O-Matic",     req_items={{keyid.grindboots}, {keyid.pda,keyid.thruster_pack}} },
+    {id=0x22, name="Bolt Grabber",    req_items={{keyid.hydro_pack,keyid.o2_mask}, {keyid.pda}} },
     {id=0x23, name="Persuader",       req_items={{keyid.raritanium,keyid.trespasser,keyid.hydrodisplacer}, {keyid.raritanium,keyid.o2_mask}} },
-    {id=0x30, name="Zoomerator",      req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },
+    {id=0x30, name="Zoomerator",      req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} },
     {id=0x31, name="Raritanium",      req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}} },
     {id=0x32, name="Codebot",         req_items={} },
-    {id=0x34, name="Premium Nanotech",req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}, {keyid.o2_mask,keyid.PDA}} },
-    {id=0x35, name="Ultra Nanotech",  req_items={{keyid.premium_nanotech,keyid.o2_mask,keyid.heli_pack}, {keyid.premium_nanotech,keyid.o2_mask,keyid.thruster_pack}, {keyid.premium_nanotech,keyid.o2_mask,keyid.PDA}} },
+    {id=0x34, name="Premium Nanotech",req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}, {keyid.o2_mask,keyid.pda}} },
+    {id=0x35, name="Ultra Nanotech",  req_items={{keyid.premium_nanotech,keyid.o2_mask,keyid.heli_pack}, {keyid.premium_nanotech,keyid.o2_mask,keyid.thruster_pack}, {keyid.premium_nanotech,keyid.o2_mask,keyid.pda}} },
 }
 
 infobots = {
-    {id=0x01, req_items={} },				                             -- Veldin1 -> Novalis
-    {id=0x02, req_items={} },				                             -- Novalis -> Aridia
-    {id=0x03, req_items={} },				                             -- Novalis -> Kerwan
-    {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} },                      -- Kerwan -> Eudora
-    {id=0x05, req_items={} },				                             -- Blarg -> Rilgar
-    {id=0x06, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.decoy_glove}} },              -- Eudora -> Blarg
-    {id=0x07, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} },                      -- Rilgar -> Umbris
-    {id=0x08, req_items={{keyid.swingshot,keyid.heli_pack}, {keyid.swingshot,keyid.thruster_pack}} },            -- Umbris -> Batalia
-    {id=0x09, req_items={{keyid.grindboots}, {keyid.heli_pack,keyid.PDA}, {keyid.thruster_pack,keyid.PDA}} },    -- Batalia -> Gaspar
-    {id=0x0A, req_items={} },				                             -- Batalia -> Orxon
-    {id=0x0B, req_items={} },				                             -- Orxon -> Pokitaru
-    {id=0x0C, req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}} },            -- Orxon -> Hoven
-    {id=0x0D, req_items={} },				                                       -- Hoven -> Gemlik
-    {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} }, -- Gemlik -> Oltanis
-    {id=0x0F, req_items={{keyid.grindboots}, {keyid.PDA}} },                      -- Oltanis -> Quartu
-    {id=0x10, req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },      -- Quartu -> KaleboIII
-    {id=0x11, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.PDA}} },              -- Quartu -> Fleet
-    {id=0x12, req_items={{keyid.thruster_pack}, {keyid.magneboots}, {keyid.decoy_glove}} }               -- Fleet -> Veldin2
+    {id=0x01, req_items={} }, -- Veldin1 -> Novalis
+    {id=0x02, req_items={} }, -- Novalis -> Aridia
+    {id=0x03, req_items={} }, -- Novalis -> Kerwan
+    {id=0x04, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} }, -- Kerwan -> Eudora
+    {id=0x05, req_items={} }, -- Blarg -> Rilgar
+    {id=0x06, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.decoy_glove}} }, -- Eudora -> Blarg
+    {id=0x07, req_items={{keyid.heli_pack}, {keyid.thruster_pack}} }, -- Rilgar -> Umbris
+    {id=0x08, req_items={{keyid.swingshot,keyid.heli_pack}, {keyid.swingshot,keyid.thruster_pack}} }, -- Umbris -> Batalia
+    {id=0x09, req_items={{keyid.grindboots}, {keyid.heli_pack,keyid.pda}, {keyid.thruster_pack,keyid.pda}} }, -- Batalia -> Gaspar
+    {id=0x0A, req_items={} }, -- Batalia -> Orxon
+    {id=0x0B, req_items={} }, -- Orxon -> Pokitaru
+    {id=0x0C, req_items={{keyid.o2_mask,keyid.heli_pack}, {keyid.o2_mask,keyid.thruster_pack}} }, -- Orxon -> Hoven
+    {id=0x0D, req_items={} }, -- Hoven -> Gemlik
+    {id=0x0E, req_items={{keyid.swingshot,keyid.magneboots,keyid.trespasser,keyid.devastator}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Gemlik -> Oltanis
+    {id=0x0F, req_items={{keyid.grindboots}, {keyid.pda}} }, -- Oltanis -> Quartu
+    {id=0x10, req_items={{keyid.swingshot}, {keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Quartu -> KaleboIII
+    {id=0x11, req_items={{keyid.heli_pack}, {keyid.thruster_pack}, {keyid.pda}} }, -- Quartu -> Fleet
+    {id=0x12, req_items={{keyid.thruster_pack}, {keyid.magneboots}, {keyid.decoy_glove}} } -- Fleet -> Veldin2
 }
 
 planets = {
@@ -79,7 +79,7 @@ planets = {
     {id=11, name="Pokitaru", infobots={},                           items={keyid.thruster_pack,keyid.o2_mask,keyid.persuader,keyid.decoy_glove} },
     {id=12, name="Hoven",    infobots={keyid.gemlik},               items={keyid.raritanium,keyid.hydro_pack,keyid.drone_device} },
     {id=13, name="Gemlik",   infobots={keyid.oltanis},              items={} },
-    {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.PDA,keyid.tesla_claw,keyid.morph_o_ray} },
+    {id=14, name="Oltanis",  infobots={keyid.quartu},               items={keyid.pda,keyid.tesla_claw,keyid.morph_o_ray} },
     {id=15, name="Quartu",   infobots={keyid.kalebo,keyid.fleet},   items={keyid.bolt_grabber} },
     {id=16, name="KaleboIII",infobots={},                           items={keyid.hologuise,keyid.map_o_matic} },
     {id=17, name="Fleet",    infobots={keyid.veldin},               items={keyid.codebot} }

--- a/table_id.lua
+++ b/table_id.lua
@@ -1,0 +1,68 @@
+-- key item ids
+keyid = {
+-- packs
+	heli_pack=2,
+	thruster_pack=3,
+	hydro_pack=4,
+-- helmets
+	sonic_summoner=5,
+	o2_mask=6,
+	pilots_helmet=7,
+-- gadgets
+	swingshot=0xc,
+	hydrodisplacer=0x16,
+	trespasser=0x1a,
+	metal_detector=0x1b,
+    hologuise=0x1f,
+    pda=0x20,
+-- boots
+	magneboots=0x1c,
+	grindboots=0x1d,
+-- items
+	hoverboard=0x1e,
+	map_o_matic=0x21,
+	bolt_grabber=0x22,
+	persuader=0x23,
+	zoomerator=0x30,
+	raritanium=0x31,
+	codebot=0x32,
+	premium_nanotech=0x34,
+	ultra_nanotech=0x35,
+-- vendor weapons
+	devastator=0xb,
+	visibomb=0xd,
+	taunter=0xe,
+	blaster=0xf,
+	pyrociter=0x10,
+	mine_glove=0x11,
+	walloper=0x12,
+	tesla_claw=0x13,
+	glove_of_doom=0x14,
+	drone_device=0x18,
+	decoy_glove=0x19,
+-- check weapons
+	bomb_glove=10, -- currently unused
+	suck_cannon=0x9,
+	morph_o_ray=0x15,
+	ryno=0x17,
+	
+-- infobots
+	novalis=1,
+	aridia=2,
+	kerwan=3,
+	eudora=4,
+	rilgar=5,
+	blarg=6,
+	umbris=7,
+	batalia=8,
+	gaspar=9,
+	orxon=10,
+	pokitaru=0xb,
+	hoven=0xc,
+	gemlik=0xd,
+	oltanis=0xe,
+	quartu=0xf,
+	kalebo=0x10,
+	fleet=0x11,
+	veldin=0x12,
+}


### PR DESCRIPTION
If someone wants to make their own custom settings, figuring out what object 0x1A is feels pretty rough. This way, using the added table_id.lua you can replace '0x1A' with 'keyid.trespasser'.