### PR TITLE
Descriptive Location Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ratchet & Clank 1 Randomizer
 
-## [Download](https://github.com/bordplate/rac1-randomizer/releases/download/v1.1.2/randomizer.zip)
+## [Download](https://github.com/bordplate/rac1-randomizer/releases/download/v1.2/randomizer.zip)
 
 ## [Discord community](https://discord.gg/EuQKGes33C)
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 The randomizer is currently only supported on PS3 with digital PAL copy of Ratchet & Clank 1. There are no plans to support emulator or NTSC at this point. 
 
 ## EmoTracker item tracker
-Item tracker for EmoTracker is available, courtesy of Myth197 and DukeDragon28.  
-[github.com/Myth197/RAC-Rando-Tracker](https://github.com/Myth197/RAC-Rando-Tracker)
+Item tracker for [EmoTracker](https://emotracker.net/service/install/emotracker_setup.exe) is available, courtesy of Myth197 and DukeDragon28.
 
 ## Installation
 A homebrew enabled PS3 with WebMAN is required. Then use [RaCMAN](https://github.com/MichaelRelaxen/racman).  
@@ -29,6 +28,8 @@ Add `# graph: false` to the top of the `seed.txt` file to disable debug graph ge
 ## What does it do?
 - Infobots and weapons/items/gadgets are randomized.
 	- You always get infobots where you get infobots, and always weapons/items/gadgets where you get those. So there are two randomized pools. 
+	- Weapons from Vendors are randomized, any Planets you reach that would normally unlock a new weapon in the vendor in the vanilla game will add a randomized item to the Vendors.
+	- Items in Vendors will always have their original price, for example the RYNO will always cost 150,000 Bolts wherever you try and buy it from.
 - Randomizer makes sure to generate solvable paths
 - Bolt denominations are increased to avoid excessive bolt grinding
   - 1 bolt -> 5 bolts

--- a/logic0_Casual.lua
+++ b/logic0_Casual.lua
@@ -1,80 +1,80 @@
 items = {
-  {id=0x02, name="Heli-pack",       req_items={} },
-  {id=0x03, name="Thruster-pack",   req_items={} },
-  {id=0x04, name="Hydro-pack",      req_items={{0x16}} },
-  {id=0x05, name="Sonic Summoner",  req_items={{0x30}} },
-  {id=0x06, name="O2 Mask",         req_items={{0x07}} },
-  {id=0x07, name="Pilot's Helmet",  req_items={} },
-  {id=0x09, name="Suck Cannon",     req_items={{0x02}, {0x03}} },
-  {id=0x0B, name="Devastator",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x0C, name="Swingshot",       req_items={} },
-  {id=0x0D, name="Visibomb",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x0E, name="Taunter",         req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x0F, name="Blaster",         req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x10, name="Pyrocitor",       req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x11, name="Mine Glove",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x12, name="Walloper",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x13, name="Tesla Claw",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x14, name="Glove of Doom",   req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x15, name="Morph-O-Ray",     req_items={{0x0C}} },
-  {id=0x16, name="Hydrodisplacer",  req_items={{0x1A}} },
-  {id=0x17, name="R.Y.N.O.",        req_items={{0x1B,0x02}, {0x1B,0x03}} },
-  {id=0x18, name="Drone Device",    req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x19, name="Decoy Glove",     req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-  {id=0x1A, name="Trespasser",      req_items={{0x0C}} },
-  {id=0x1B, name="MetalDetector",   req_items={{0x1C}} },
-  {id=0x1C, name="Magneboots",      req_items={} },
-  {id=0x1D, name="Grindboots",      req_items={{0x0C}} },
-  {id=0x1E, name="Hoverboard",      req_items={} },
-  {id=0x1F, name="Hologuise",       req_items={{0x1E,0x02,0x0C,0x1D}, {0x1E,0x03,0x0C,0x1D}} },
-  {id=0x20, name="PDA",             req_items={{0x1C}} },
-  {id=0x21, name="Map-O-Matic",     req_items={{0x1D}} },
-  {id=0x22, name="Bolt Grabber",    req_items={{0x04,0x06}} },
-  {id=0x23, name="Persuader",       req_items={{0x1A,0x31,0x16}} },
-  {id=0x30, name="Zoomerator",      req_items={{0x1E,0x02}, {0x1E,0x03}} },
-  {id=0x31, name="Raritanium",      req_items={{0x0C,0x02}, {0x0C,0x03}} },
-  {id=0x32, name="Codebot",         req_items={{0x04,0x06}} },
-  {id=0x34, name="Premium Nanotech",req_items={{0x06,0x02}, {0x06,0x03}} },
-  {id=0x35, name="Ultra Nanotech",  req_items={{0x06,0x03,0x34,0x1B}, {0x06,0x02,0x34,0x1B} }},
+    {id=0x02, 	location="Al's Shop",			host_item="Heli-pack",			req_items={} },													 									--Kerwan
+    {id=0x03, 	location="Bob's Shop",			host_item="Thruster-pack",		req_items={} },											 											--Poki
+    {id=0x04, 	location="Edwina's Shop",		host_item="Hydro-pack",			req_items={{0x16}} },										 										--Hoven
+    {id=0x05, 	location="Skidd's Agent",		host_item="Sonic Summoner",		req_items={{0x30}} },									 											--Aridia
+    {id=0x06, 	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07}} },												 								--Poki
+    {id=0x07, 	location="Pilot's Helmet",		host_item="Pilot's Helmet",		req_items={} },										 												--Gaspar
+	{id=0x09, 	location="Suck Cannon",			host_item="Suck Cannon",		req_items={{0x02}, {0x03}} },								 										--Eudora
+	{id=0x0B, 	location="Vendor",				host_item="Devastator",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Batalia
+	{id=0x0C, 	location="Fitness Course",		host_item="Swingshot",			req_items={} }, 											 										--Kerwan
+	{id=0x0D, 	location="Vendor",				host_item="Visibomb",			req_items={{0x06}}, 									ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Orxon
+	{id=0x0E, 	location="Vendor",				host_item="Taunter",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Blarg
+	{id=0x0F, 	location="Vendor",				host_item="Blaster",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Kerwan
+	{id=0x10, 	location="Vendor",				host_item="Pyrocitor",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Novalis	
+	{id=0x11, 	location="Vendor",				host_item="Mine Glove",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Rilgar
+	{id=0x12, 	location="Vendor",				host_item="Walloper",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Gaspar
+	{id=0x13, 	location="Vendor",				host_item="Tesla Claw",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Oltanis
+	{id=0x14, 	location="Vendor",				host_item="Glove of Doom",		req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Eudora
+	{id=0x15, 	location="Morph-O-Ray",			host_item="Morph-O-Ray",		req_items={{0x0C}} }, 											 									--Oltanis
+	{id=0x16, 	location="Outside",				host_item="Hydrodisplacer", 	req_items={{0x1A}} }, 											 									--Blarg
+	{id=0x17, 	location="Shady Salesman",		host_item="R.Y.N.O.",			req_items={{0x1B, 0x02}, {0x1B, 0x03}} },					 										--Rilgar
+	{id=0x18, 	location="Vendor",				host_item="Drone Device",		req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Hoven
+	{id=0x19, 	location="Vendor",				host_item="Decoy Glove",		req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Poki
+	{id=0x1A, 	location="Construction Zone",	host_item="Trespasser",			req_items={{0x0C}} },								 												--Aridia
+    {id=0x1B, 	location="Turret Fight", 		host_item="Metaldetector",		req_items={{0x1C}} },									 											--Batalia
+    {id=0x1C, 	location="Clank 1st Item",		host_item="Magneboots",			req_items={} },										 												--Orxon
+    {id=0x1D, 	location="Alien Queen",			host_item="Grindboots",			req_items={{0x0C}} },										 										--Blarg
+    {id=0x1E, 	location="Save Skidd",			host_item="Hoverboard",			req_items={} },											 											--Aridia
+    {id=0x1F, 	location="Hoverboard Race",		host_item="Hologuise",			req_items={{0x1E, 0x02, 0x0C, 0x1D}, {0x1E, 0x03, 0x0C, 0x1D}} },	 								--KaleboIII
+    {id=0x20, 	location="Steve",				host_item="PDA",				req_items={{0x1C}} },							 													--Oltanis
+    {id=0x21, 	location="Grind Rail",			host_item="Map-O-Matic",		req_items={{0x1D}} },							 													--KaleboIII
+    {id=0x22, 	location="Water path",			host_item="Bolt Grabber",		req_items={{0x04, 0x06}} },							 												--Quartu
+    {id=0x23, 	location="Water Lab",			host_item="Persuader",			req_items={{0x1A, 0x31, 0x16}} },				 													--Poki
+    {id=0x30, 	location="Hoverboard Race",		host_item="Zoomerator",			req_items={{0x1E, 0x02}, {0x1E, 0x03}} },				 											--Rilgar
+    {id=0x31, 	location="Drill Guy",			host_item="Raritanium",			req_items={{0x0C, 0x02}, {0x0C, 0x03}} },					 										--Hoven
+    {id=0x32, 	location="Water path",			host_item="Codebot",			req_items={{0x04, 0x06}} },							 												--Fleet
+    {id=0x34, 	location="Nanotech Vendor 1",	host_item="Premium Nanotech",	req_items={{0x06, 0x02}, {0x06, 0x03}} },					 										--Orxon
+    {id=0x35, 	location="Nanotech Vendor 2",	host_item="Ultra Nanotech",		req_items={{0x06, 0x03, 0x34, 0x1B}, {0x06, 0x02, 0x34, 0x1B} }}, 									--Orxon
 }
 
 infobots = {
-  {id=0x01, req_items={} },                                 -- Veldin1 -> Novalis
-  {id=0x02, req_items={} },                                 -- Novalis -> Aridia
-  {id=0x03, req_items={} },                                 -- Novalis -> Kerwan
-  {id=0x04, req_items={{0x02}, {0x03}} },                   -- Kerwan -> Eudora
-  {id=0x05, req_items={} },                                 -- Blarg -> Rilgar
-  {id=0x06, req_items={{0x1A,0x0C,0x02}, {0x1A,0x0C,0x03}} }, -- Eudora -> Blarg
-  {id=0x07, req_items={{0x0C,0x16}} },                      -- Rilgar -> Umbris
-  {id=0x08, req_items={{0x0C,0x16}} },                      -- Umbris -> Batalia
-  {id=0x09, req_items={{0x1D}} },                           -- Batalia -> Gaspar
-  {id=0x0A, req_items={} },                                 -- Batalia -> Orxon
-  {id=0x0B, req_items={} },                                 -- Orxon -> Pokitaru
-  {id=0x0C, req_items={{0x06,0x0C,0x1C,0x03}} },            -- Orxon -> Hoven
-  {id=0x0D, req_items={} },                                 -- Hoven -> Gemlik
-  {id=0x0E, req_items={{0x0C, 0x1C, 0x1A, 0x0B}, {0x0C, 0x1C, 0x1A, 0x0D}} },         -- Gemlik -> Oltanis
-  {id=0x0F, req_items={{0x1D}} },                           -- Oltanis -> Quartu
-  {id=0x10, req_items={{0x0C}} },                           -- Quartu -> KaleboIII
-  {id=0x11, req_items={{0x03,0x0C,0x1F}} },                 -- Quartu -> Fleet
-  {id=0x12, req_items={{0x1C,0x1F}} }                       -- Fleet -> Veldin2
+    {id=0x01,	req_items={} },																		-- Novalis "infobot" on Veldin1 Clank
+    {id=0x02,	req_items={} },																		-- Aridia infobot on Novalis, Water works
+	{id=0x03,	req_items={} },																		-- Kerwan infobot on Novalis, Save the Chairman 
+    {id=0x04,	req_items={{0x02}, {0x03}} },														-- Eudora infobot on Kerwan, Train
+    {id=0x05,	req_items={} },																		-- Rilgar infobot on Blarg, Warship
+    {id=0x06,	req_items={{0x1A, 0x0C, 0x02},{0x1A, 0x0C, 0x03}}},									-- Blarg infobot on Eudora, Robot Lieutenant
+    {id=0x07,	req_items={{0x0C, 0x16, 0x02},{0x0C, 0x16, 0x03}}},									-- Umbris infobot on Rilgar, Qwark's Trailer
+    {id=0x08,	req_items={{0x0C, 0x16, 0x02, 0x0B}, {0x0C, 0x16, 0x03, 0x0B}, {0x0C, 0x16, 0x02, 0x0D}, {0x0C, 0x16, 0x03, 0x0D}, {0x0C, 0x16, 0x02, 0x0F}, {0x0C, 0x16, 0x03, 0x0F}, {0x0C, 0x16, 0x02, 0x10}, {0x0C, 0x16, 0x03, 0x10}, {0x0C, 0x16, 0x02, 0x11}, {0x0C, 0x16, 0x03, 0x11}, {0x0C, 0x16, 0x02, 0x12}, {0x0C, 0x16, 0x03, 0x12}, {0x0C, 0x16, 0x02, 0x13}, {0x0C, 0x16, 0x03, 0x13}, {0x0C, 0x16, 0x02, 0x17}, {0x0C, 0x16, 0x03, 0x17}}},	-- Batalia infobot on Umbris, Snagglebeast
+    {id=0x09,	req_items={{0x1D}} },																-- Gaspar infobot on Batalia, Grind Rail
+    {id=0x0A,	req_items={} },																		-- Orxon infobot on Batalia, Commando
+    {id=0x0B,	req_items={} },																		-- Pokitaru infobot on Orxon, Clank 2
+    {id=0x0C,	req_items={{0x06,0x0C,0x1C, 0x03}} },												-- Hoven infobot on Orxon, Chase the infobot
+    {id=0x0D,	req_items={{0x09},{0x0B},{0x0D},{0x0F},{0x10},{0x13},{0x17},{0xc,2,5},{0xc,3,5}} },	-- Gemlik infobot on Hoven, Turret Fight
+    {id=0x0E,	req_items={{0x0C, 0x1C, 0x1A, 0x0B}, {0x0C, 0x1C, 0x1A, 0x0D}} },					-- Oltanis infobot on Gemlik, Defeat Qwark
+    {id=0x0F,	req_items={{0x1D}} }, 																-- Quartu infobot on Oltanis, Deaf guy
+    {id=0x10,	req_items={{0x0C}} },    															-- KaleboIII infobot on Quartu, Giant Clank Fight
+    {id=0x11,	req_items={{0x03, 0x0C, 0x1F}} },													-- Fleet infobot on Quartu, Clank's Mum
+    {id=0x12,	req_items={{0x1C,0x1F}} }															-- Veldin2 infobot on Drek's Fleet, Battle through the ships
 }
 
 planets = {
-  {id=1,  name="Novalis",  infobots={0x02,0x03},  items={0x10} },
-  {id=2,  name="Aridia",   infobots={},           items={0x1E,0x1A,0x05} },
-  {id=3,  name="Kerwan",   infobots={0x04},       items={0x0C,0x02,0x0F} },
-  {id=4,  name="Eudora",   infobots={0x06},       items={0x14,0x09} },
-  {id=5,  name="Rilgar",   infobots={0x07},       items={0x30,0x11,0x17} },
-  {id=6,  name="Blarg",    infobots={0x05},       items={0x1D,0x16,0x0E} },
-  {id=7,  name="Umbris",   infobots={0x08},       items={} },
-  {id=8,  name="Batalia",  infobots={0x09,0x0A},  items={0x1B,0x0B} },
-  {id=9,  name="Gaspar",   infobots={},           items={0x07,0x12} },
-  {id=10, name="Orxon",    infobots={0x0B,0x0C},  items={0x34,0x35,0x1C,0x0D} },
-  {id=11, name="Pokitaru", infobots={},           items={0x03,0x06,0x23,0x19} },
-  {id=12, name="Hoven",    infobots={0x0D},       items={0x31,0x04,0x18} },
-  {id=13, name="Gemlik",   infobots={0x0E},       items={} },
-  {id=14, name="Oltanis",  infobots={0x0F},       items={0x20,0x13,0x15} },
-  {id=15, name="Quartu",   infobots={0x10,0x11},  items={0x22} },
-  {id=16, name="KaleboIII",infobots={},           items={0x1F,0x21} },
-  {id=17, name="Fleet",    infobots={0x12},       items={0x32} }
+	{id=0x01,	location="Clank",				host_item="Novalis",	infobots={0x02,0x03},	items={0x10}},						--Veldin1
+	{id=0x02,	location="Water works",			host_item="Aridia",		infobots={},			items={0x1E, 0x1A, 0x05}},			--Novalis
+	{id=0x03,	location="Save the Chairman",	host_item="Kerwan",		infobots={0x04},		items={0x0C, 0x02, 0x0F}},			--Novalis
+	{id=0x04,	location="Train",				host_item="Eudora",		infobots={0x06},		items={0x14, 0x9}},					--Kerwan
+	{id=0x05,	location="Warship",				host_item="Rilgar",		infobots={0x07},		items={0x30, 0x11, 0x17}},			--Blarg
+	{id=0x06,	location="Robot Lieutenant",	host_item="Blarg",		infobots={0x05},		items={0x1D, 0x16, 0x0E}},			--Eudora
+	{id=0x07,	location="Qwark's Trailer",		host_item="Umbris",		infobots={8},			items={}},							--Rilgar
+	{id=0x08,	location="Snagglebeast",		host_item="Batalia",	infobots={0x09, 10},	items={0x1B, 0x0B}},				--Umbris
+	{id=0x09,	location="Grind Rail",			host_item="Gaspar",		infobots={},			items={0x07, 0x12}},				--Batalia
+	{id=0x0A,	location="Commando",			host_item="Orxon",		infobots={0x0B, 0x0C},	items={0x34, 0x35, 0x1C, 0x0D}},	--Batalia
+	{id=0x0B,	location="Clank 2nd Item",		host_item="Pokitaru",	infobots={},			items={0x03, 0x06, 0x23, 0x19}},	--Orxon
+	{id=0x0C,	location="Chase the Infobot",	host_item="Hoven",		infobots={0x0D},		items={0x31, 0x04, 0x18}},			--Orxon
+	{id=0x0D,	location="Turret Fight",		host_item="Gemlik",		infobots={0x0E},		items={}},							--Hoven
+	{id=0x0E,	location="Defeat Qwark",		host_item="Oltanis",	infobots={0x0F},		items={0x20, 0x13, 0x15}},			--Gemlik
+	{id=0x0F,	location="Deaf Guy",			host_item="Quartu",		infobots={0x10, 0x11},	items={0x22}},						--Oltanis
+	{id=0x10,	location="Giant Clank Fight",	host_item="KaleboIII",	infobots={},			items={0x1F, 0x21}},				--Quartu
+	{id=0x11,	location="Clank's Mum",			host_item="Fleet",		infobots={0x12},		items={0x32}}						--Quartu
 }

--- a/logic0_Casual.lua
+++ b/logic0_Casual.lua
@@ -3,12 +3,12 @@ items = {
     {id=0x03, 	location="Bob's Shop",			host_item="Thruster-pack",		req_items={} },											 											--Poki
     {id=0x04, 	location="Edwina's Shop",		host_item="Hydro-pack",			req_items={{0x16}} },										 										--Hoven
     {id=0x05, 	location="Skidd's Agent",		host_item="Sonic Summoner",		req_items={{0x30}} },									 											--Aridia
-    {id=0x06, 	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07, 0x03}} },												 								--Poki
+    {id=0x06, 	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07, 0x03}} },												 							--Poki
     {id=0x07, 	location="Pilot's Helmet",		host_item="Pilot's Helmet",		req_items={} },										 												--Gaspar
 	{id=0x09, 	location="Suck Cannon",			host_item="Suck Cannon",		req_items={{0x02}, {0x03}} },								 										--Eudora
 	{id=0x0B, 	location="Vendor",				host_item="Devastator",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Batalia
 	{id=0x0C, 	location="Fitness Course",		host_item="Swingshot",			req_items={} }, 											 										--Kerwan
-	{id=0x0D, 	location="Vendor",				host_item="Visibomb",			req_items={{0x06}}, 									ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Orxon
+	{id=0x0D, 	location="Vendor",				host_item="Visibomb",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Orxon
 	{id=0x0E, 	location="Vendor",				host_item="Taunter",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Blarg
 	{id=0x0F, 	location="Vendor",				host_item="Blaster",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Kerwan
 	{id=0x10, 	location="Vendor",				host_item="Pyrocitor",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Novalis	

--- a/logic0_Casual.lua
+++ b/logic0_Casual.lua
@@ -3,7 +3,7 @@ items = {
     {id=0x03, 	location="Bob's Shop",			host_item="Thruster-pack",		req_items={} },											 											--Poki
     {id=0x04, 	location="Edwina's Shop",		host_item="Hydro-pack",			req_items={{0x16}} },										 										--Hoven
     {id=0x05, 	location="Skidd's Agent",		host_item="Sonic Summoner",		req_items={{0x30}} },									 											--Aridia
-    {id=0x06, 	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07}} },												 								--Poki
+    {id=0x06, 	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07, 0x03}} },												 								--Poki
     {id=0x07, 	location="Pilot's Helmet",		host_item="Pilot's Helmet",		req_items={} },										 												--Gaspar
 	{id=0x09, 	location="Suck Cannon",			host_item="Suck Cannon",		req_items={{0x02}, {0x03}} },								 										--Eudora
 	{id=0x0B, 	location="Vendor",				host_item="Devastator",			req_items={}, 											ill_items={0x30, 0x31, 0x32, 0x34, 0x35} },	--Batalia

--- a/logic0_Casual.lua
+++ b/logic0_Casual.lua
@@ -39,24 +39,24 @@ items = {
 }
 
 infobots = {
-    {id=0x01,	req_items={} },																		-- Novalis "infobot" on Veldin1 Clank
-    {id=0x02,	req_items={} },																		-- Aridia infobot on Novalis, Water works
-	{id=0x03,	req_items={} },																		-- Kerwan infobot on Novalis, Save the Chairman 
-    {id=0x04,	req_items={{0x02}, {0x03}} },														-- Eudora infobot on Kerwan, Train
-    {id=0x05,	req_items={} },																		-- Rilgar infobot on Blarg, Warship
-    {id=0x06,	req_items={{0x1A, 0x0C, 0x02},{0x1A, 0x0C, 0x03}}},									-- Blarg infobot on Eudora, Robot Lieutenant
-    {id=0x07,	req_items={{0x0C, 0x16, 0x02},{0x0C, 0x16, 0x03}}},									-- Umbris infobot on Rilgar, Qwark's Trailer
+    {id=0x01,	req_items={} },																						-- Novalis "infobot" on Veldin1 Clank
+    {id=0x02,	req_items={} },																						-- Aridia infobot on Novalis, Water works
+	{id=0x03,	req_items={} },																						-- Kerwan infobot on Novalis, Save the Chairman 
+    {id=0x04,	req_items={{0x02}, {0x03}} },																		-- Eudora infobot on Kerwan, Train
+    {id=0x05,	req_items={} },																						-- Rilgar infobot on Blarg, Warship
+    {id=0x06,	req_items={{0x1A, 0x0C, 0x02},{0x1A, 0x0C, 0x03}}},													-- Blarg infobot on Eudora, Robot Lieutenant
+    {id=0x07,	req_items={{0x0C, 0x16, 0x02},{0x0C, 0x16, 0x03}}},													-- Umbris infobot on Rilgar, Qwark's Trailer
     {id=0x08,	req_items={{0x0C, 0x16, 0x02, 0x0B}, {0x0C, 0x16, 0x03, 0x0B}, {0x0C, 0x16, 0x02, 0x0D}, {0x0C, 0x16, 0x03, 0x0D}, {0x0C, 0x16, 0x02, 0x0F}, {0x0C, 0x16, 0x03, 0x0F}, {0x0C, 0x16, 0x02, 0x10}, {0x0C, 0x16, 0x03, 0x10}, {0x0C, 0x16, 0x02, 0x11}, {0x0C, 0x16, 0x03, 0x11}, {0x0C, 0x16, 0x02, 0x12}, {0x0C, 0x16, 0x03, 0x12}, {0x0C, 0x16, 0x02, 0x13}, {0x0C, 0x16, 0x03, 0x13}, {0x0C, 0x16, 0x02, 0x17}, {0x0C, 0x16, 0x03, 0x17}}},	-- Batalia infobot on Umbris, Snagglebeast
-    {id=0x09,	req_items={{0x1D}} },																-- Gaspar infobot on Batalia, Grind Rail
-    {id=0x0A,	req_items={} },																		-- Orxon infobot on Batalia, Commando
-    {id=0x0B,	req_items={} },																		-- Pokitaru infobot on Orxon, Clank 2
-    {id=0x0C,	req_items={{0x06,0x0C,0x1C, 0x03}} },												-- Hoven infobot on Orxon, Chase the infobot
-    {id=0x0D,	req_items={{0x09},{0x0B},{0x0D},{0x0F},{0x10},{0x13},{0x17},{0xc,2,5},{0xc,3,5}} },	-- Gemlik infobot on Hoven, Turret Fight
-    {id=0x0E,	req_items={{0x0C, 0x1C, 0x1A, 0x0B}, {0x0C, 0x1C, 0x1A, 0x0D}} },					-- Oltanis infobot on Gemlik, Defeat Qwark
-    {id=0x0F,	req_items={{0x1D}} }, 																-- Quartu infobot on Oltanis, Deaf guy
-    {id=0x10,	req_items={{0x0C}} },    															-- KaleboIII infobot on Quartu, Giant Clank Fight
-    {id=0x11,	req_items={{0x03, 0x0C, 0x1F}} },													-- Fleet infobot on Quartu, Clank's Mum
-    {id=0x12,	req_items={{0x1C,0x1F}} }															-- Veldin2 infobot on Drek's Fleet, Battle through the ships
+    {id=0x09,	req_items={{0x1D}} },																				-- Gaspar infobot on Batalia, Grind Rail
+    {id=0x0A,	req_items={} },																						-- Orxon infobot on Batalia, Commando
+    {id=0x0B,	req_items={} },																						-- Pokitaru infobot on Orxon, Clank 2
+    {id=0x0C,	req_items={{0x06, 0x0C, 0x1C, 0x03}} },																-- Hoven infobot on Orxon, Chase the infobot
+    {id=0x0D,	req_items={{0x09},{0x0B},{0x0D},{0x0F},{0x10},{0x13},{0x17},{0x0C,0x02,0x05},{0x0C,0x03,0x05}} },	-- Gemlik infobot on Hoven, Turret Fight
+    {id=0x0E,	req_items={{0x0C, 0x1C, 0x1A, 0x0B}, {0x0C, 0x1C, 0x1A, 0x0D}} },									-- Oltanis infobot on Gemlik, Defeat Qwark
+    {id=0x0F,	req_items={{0x1D}} }, 																				-- Quartu infobot on Oltanis, Deaf guy
+    {id=0x10,	req_items={{0x0C}} },    																			-- KaleboIII infobot on Quartu, Giant Clank Fight
+    {id=0x11,	req_items={{0x03, 0x0C, 0x1F}} },																	-- Fleet infobot on Quartu, Clank's Mum
+    {id=0x12,	req_items={{0x1C,0x1F}} }																			-- Veldin2 infobot on Drek's Fleet, Battle through the ships
 }
 
 planets = {
@@ -67,7 +67,7 @@ planets = {
 	{id=0x05,	location="Warship",				host_item="Rilgar",		infobots={0x07},		items={0x30, 0x11, 0x17}},			--Blarg
 	{id=0x06,	location="Robot Lieutenant",	host_item="Blarg",		infobots={0x05},		items={0x1D, 0x16, 0x0E}},			--Eudora
 	{id=0x07,	location="Qwark's Trailer",		host_item="Umbris",		infobots={8},			items={}},							--Rilgar
-	{id=0x08,	location="Snagglebeast",		host_item="Batalia",	infobots={0x09, 10},	items={0x1B, 0x0B}},				--Umbris
+	{id=0x08,	location="Snagglebeast",		host_item="Batalia",	infobots={0x09, 0x10},	items={0x1B, 0x0B}},				--Umbris
 	{id=0x09,	location="Grind Rail",			host_item="Gaspar",		infobots={},			items={0x07, 0x12}},				--Batalia
 	{id=0x0A,	location="Commando",			host_item="Orxon",		infobots={0x0B, 0x0C},	items={0x34, 0x35, 0x1C, 0x0D}},	--Batalia
 	{id=0x0B,	location="Clank 2nd Item",		host_item="Pokitaru",	infobots={},			items={0x03, 0x06, 0x23, 0x19}},	--Orxon

--- a/logic1_Speed.lua
+++ b/logic1_Speed.lua
@@ -1,80 +1,80 @@
 items = {
-    {id=0x02, name="Heli-pack",       req_items={} },
-    {id=0x03, name="Thruster-pack",   req_items={} },
-    {id=0x04, name="Hydro-pack",      req_items={{0x16}, {0x02}, {0x03}, {0x20}} },
-    {id=0x05, name="Sonic Summoner",  req_items={{0x30}} },
-    {id=0x06, name="O2 Mask",         req_items={{0x07}} },
-    {id=0x07, name="Pilot's Helmet",  req_items={} },
-    {id=0x09, name="Suck Cannon",     req_items={{0x02}, {0x03}, {0x20}} },
-    {id=0x0B, name="Devastator",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x0C, name="Swingshot",       req_items={} },
-    {id=0x0D, name="Visibomb",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x0E, name="Taunter",         req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x0F, name="Blaster",         req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x10, name="Pyrocitor",       req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x11, name="Mine Glove",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x12, name="Walloper",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x13, name="Tesla Claw",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x14, name="Glove of Doom",   req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x15, name="Morph-O-Ray",     req_items={{0x0C}, {0x20}} },
-    {id=0x16, name="Hydrodisplacer",  req_items={{0x1A}, {0x02}, {0x03}, {0x20}} },
-    {id=0x17, name="R.Y.N.O.",        req_items={{0x1B,0x02}, {0x1B,0x03}, {0x1B,0x20}} },
-    {id=0x18, name="Drone Device",    req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x19, name="Decoy Glove",     req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x1A, name="Trespasser",      req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },
-    {id=0x1B, name="MetalDetector",   req_items={{0x1C}, {0x02}, {0x03}, {0x20}} },
-    {id=0x1C, name="Magneboots",      req_items={} },
-    {id=0x1D, name="Grindboots",      req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },
-    {id=0x1E, name="Hoverboard",      req_items={} },
-    {id=0x1F, name="Hologuise",       req_items={{0x1E,0x02}, {0x1E,0x0D}, {0x1E,0x19}, {0x03}, {0x20}} },
-    {id=0x20, name="PDA",             req_items={{0x1C}} },
-    {id=0x21, name="Map-O-Matic",     req_items={{0x1D}, {0x20}} },
-    {id=0x22, name="Bolt Grabber",    req_items={{0x04,0x06}, {0x20}, {0x02}, {0x03}} },
-    {id=0x23, name="Persuader",       req_items={{0x31,0x1A,0x16}} },
-    {id=0x30, name="Zoomerator",      req_items={{0x02}, {0x03}, {0x20}} },
-    {id=0x31, name="Raritanium",      req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },
-    {id=0x32, name="Codebot",         req_items={} },
-    {id=0x34, name="Premium Nanotech",req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },
-    {id=0x35, name="Ultra Nanotech",  req_items={{0x34,0x06,0x02}, {0x34,0x06,0x03}, {0x34,0x06,0x20}} },
+    {id=0x02, 	location="Al's Shop",			host_item="Heli-pack",			req_items={} },													 								--Kerwan
+    {id=0x03,	location="Bob's Shop",			host_item="Thruster-pack",		req_items={} },											 										--Poki
+    {id=0x04,	location="Edwina's Shop",		host_item="Hydro-pack",			req_items={{0x16}, {0x02}, {0x03}, {0x20}} },													--Hoven
+    {id=0x05,	location="Skidd's Agent",		host_item="Sonic Summoner",		req_items={{0x30}} },																			--Aridia
+    {id=0x06,	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07}} },																			--Poki
+    {id=0x07,	location="Pilot's Helmet",		host_item="Pilot's Helmet",		req_items={} },																					--Gaspar
+    {id=0x09,	location="Suck Cannon",			host_item="Suck Cannon",		req_items={{0x02}, {0x03}, {0x20}} },															--Eudora
+    {id=0x0B,	location="Vendor",				host_item="Devastator",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Batalia
+    {id=0x0C,	location="Fitness Course",		host_item="Swingshot",			req_items={} },																					--Kerwan
+    {id=0x0D,	location="Vendor",				host_item="Visibomb",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Orxon
+    {id=0x0E,	location="Vendor",				host_item="Taunter",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Blarg
+    {id=0x0F,	location="Vendor",				host_item="Blaster",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Kerwan
+    {id=0x10,	location="Vendor",				host_item="Pyrocitor",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Novalis
+    {id=0x11,	location="Vendor",				host_item="Mine Glove",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Rilgar
+    {id=0x12,	location="Vendor",				host_item="Walloper",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Gaspar
+    {id=0x13,	location="Vendor",				host_item="Tesla Claw",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Oltanis
+    {id=0x14,	location="Vendor",				host_item="Glove of Doom",		req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Eudora
+    {id=0x15,	location="Morph-O-Ray",			host_item="Morph-O-Ray",		req_items={{0x0C}, {0x20}} },																	--Oltanis
+    {id=0x16,	location="Outside",				host_item="Hydrodisplacer",		req_items={{0x1A}, {0x02}, {0x03}, {0x20}} },													--Blarg
+    {id=0x17,	location="Shady Salesman",		host_item="R.Y.N.O.",			req_items={{0x1B, 0x02}, {0x1B, 0x03}, {0x1B, 0x20}} },											--Rilgar
+    {id=0x18,	location="Vendor",				host_item="Drone Device",		req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Hoven
+    {id=0x19,	location="Vendor",				host_item="Decoy Glove",		req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Poki
+    {id=0x1A,	location="Construction Zone",	host_item="Trespasser",			req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },													--Aridia
+    {id=0x1B,	location="Turret Fight", 		host_item="MetalDetector",		req_items={{0x1C}, {0x02}, {0x03}, {0x20}} },													--Batalia
+    {id=0x1C,	location="Clank 1st Item",		host_item="Magneboots",			req_items={} },																					--Orxon
+    {id=0x1D,	location="Alien Queen",			host_item="Grindboots",			req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },													--Blarg
+    {id=0x1E,	location="Save Skidd",			host_item="Hoverboard",			req_items={} },																					--Aridia
+    {id=0x1F,	location="Hoverboard Race",		host_item="Hologuise",			req_items={{0x1E, 0x02}, {0x1E, 0x0D}, {0x1E, 0x19}, {0x03}, {0x20}} },							--KaleboIII
+    {id=0x20,	location="Steve",				host_item="PDA",				req_items={{0x1C}} },																			--Oltanis
+    {id=0x21,	location="Grind Rail",			host_item="Map-O-Matic",		req_items={{0x1D}, {0x20}} },																	--KaleboIII
+    {id=0x22,	location="Water path",			host_item="Bolt Grabber",		req_items={{0x04, 0x06}, {0x20}, {0x02}, {0x03}} },												--Quartu
+    {id=0x23,	location="Water Lab",			host_item="Persuader",			req_items={{0x31, 0x1A, 0x16}, {0x31,0x06}} },													--Poki
+    {id=0x30,	location="Hoverboard Race",		host_item="Zoomerator",			req_items={{0x02}, {0x03}, {0x20}} },															--Rilgar
+    {id=0x31,	location="Drill Guy",			host_item="Raritanium",			req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },													--Hoven
+    {id=0x32,	location="Water path",			host_item="Codebot",			req_items={} },																					--Fleet
+    {id=0x34,	location="Nanotech Vendor 1",	host_item="Premium Nanotech",	req_items={{0x06, 0x02}, {0x06, 0x03}, {0x06, 0x20}} },											--Orxon
+    {id=0x35,	location="Nanotech Vendor 2",	host_item="Ultra Nanotech",		req_items={{0x34, 0x06, 0x02}, {0x34, 0x06, 0x03}, {0x34, 0x06, 0x20}} },						--Orxon
 }
 
 infobots = {
-    {id=0x01, req_items={} },				                        -- Veldin1 -> Novalis
-    {id=0x02, req_items={} },				                        -- Novalis -> Aridia
-    {id=0x03, req_items={} },				                        -- Novalis -> Kerwan
-    {id=0x04, req_items={{0x02}, {0x03}, {0x20}} },         -- Kerwan -> Eudora
-    {id=0x05, req_items={} },				                        -- Blarg -> Rilgar
-    {id=0x06, req_items={{0x02}, {0x03}, {0x20}, {0x19}} }, -- Eudora -> Blarg
-    {id=0x07, req_items={{0x02}, {0x03}, {0x20}, {0x0C}} }, -- Rilgar -> Umbris
-    {id=0x08, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} }, -- Umbris -> Batalia
-    {id=0x09, req_items={{0x1D}, {0x02}, {0x20}} },         -- Batalia -> Gaspar
-    {id=0x0A, req_items={} },				                        -- Batalia -> Orxon
-    {id=0x0B, req_items={} },				                        -- Orxon -> Pokitaru
-    {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },         -- Orxon -> Hoven
-    {id=0x0D, req_items={} },				                                       -- Hoven -> Gemlik
-    {id=0x0E, req_items={{0x0C,0x1C,0x1A,0x0B}, {0x02}, {0x03}, {0x20}} }, -- Gemlik -> Oltanis
-    {id=0x0F, req_items={{0x1D}, {0x1C}, {0x20}} },         -- Oltanis -> Quartu
-    {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} }, -- Quartu -> KaleboIII
-    {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },         -- Quartu -> Fleet
-    {id=0x12, req_items={{0x03}, {0x1C}, {0x19}, {0x20}} }  -- Fleet -> Veldin2
+    {id=0x01, req_items={} },												-- Novalis "infobot" on Veldin1 Clank
+    {id=0x02, req_items={} },												-- Aridia infobot on Novalis, Water works
+    {id=0x03, req_items={} },												-- Kerwan infobot on Novalis, Save the Chairman 
+    {id=0x04, req_items={{0x02}, {0x03}, {0x20}} },							-- Eudora infobot on Kerwan, Train
+    {id=0x05, req_items={} },												-- Rilgar infobot on Blarg, Warship
+    {id=0x06, req_items={{0x02}, {0x03}, {0x20}, {0x19}} },					-- Blarg infobot on Eudora, Robot Lieutenant
+    {id=0x07, req_items={{0x02}, {0x03}, {0x20}, {0x0C}} },					-- Umbris infobot on Rilgar, Qwark's Trailer
+    {id=0x08, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },					-- Batalia infobot on Umbris, Snagglebeast
+    {id=0x09, req_items={{0x1D}, {0x02}, {0x20}} },							-- Gaspar infobot on Batalia, Grind Rail
+    {id=0x0A, req_items={} },												-- Orxon infobot on Batalia, Commando
+    {id=0x0B, req_items={} },												-- Pokitaru infobot on Orxon, Clank 2
+    {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },			-- Hoven infobot on Orxon, Chase the infobot
+    {id=0x0D, req_items={} },												-- Gemlik infobot on Hoven, Turret Fight
+    {id=0x0E, req_items={{0x0C,0x1C,0x1A,0x0B}, {0x02}, {0x03}, {0x20}} },	-- Oltanis infobot on Gemlik, Defeat Qwark
+    {id=0x0F, req_items={{0x1D}, {0x1C}, {0x20}} },							-- Quartu infobot on Oltanis, Deaf guy
+    {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },					-- KaleboIII infobot on Quartu, Giant Clank Fight
+    {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },							-- Fleet infobot on Quartu, Clank's Mum
+    {id=0x12, req_items={{0x03}, {0x1C}, {0x19}, {0x20}} }					-- Veldin2 infobot on Drek's Fleet, Battle through the ships
 }
 
 planets = {
-    {id=1,  name="Novalis",  infobots={0x02,0x03},  items={0x10} },
-    {id=2,  name="Aridia",   infobots={},           items={0x1E,0x1A,0x05} },
-    {id=3,  name="Kerwan",   infobots={0x04},       items={0x0C,0x02,0x0F} },
-    {id=4,  name="Eudora",   infobots={0x06},       items={0x14,0x09} },
-    {id=5,  name="Rilgar",   infobots={0x07},       items={0x30,0x11,0x17} },
-    {id=6,  name="Blarg",    infobots={0x05},       items={0x1D,0x16,0x0E} },
-    {id=7,  name="Umbris",   infobots={0x08},       items={} },
-    {id=8,  name="Batalia",  infobots={0x09,0x0A},  items={0x1B,0x0B} },
-    {id=9,  name="Gaspar",   infobots={},           items={0x07,0x12} },
-    {id=10, name="Orxon",    infobots={0x0B,0x0C},  items={0x34,0x35,0x1C,0x0D} },
-    {id=11, name="Pokitaru", infobots={},           items={0x03,0x06,0x23,0x19} },
-    {id=12, name="Hoven",    infobots={0x0D},       items={0x31,0x04,0x18} },
-    {id=13, name="Gemlik",   infobots={0x0E},       items={} },
-    {id=14, name="Oltanis",  infobots={0x0F},       items={0x20,0x13,0x15} },
-    {id=15, name="Quartu",   infobots={0x10,0x11},  items={0x22} },
-    {id=16, name="KaleboIII",infobots={},           items={0x1F,0x21} },
-    {id=17, name="Fleet",    infobots={0x12},       items={0x32} }
+    {id=1,  location="Clank",				host_item="Novalis",  infobots={0x02,0x03},  items={0x10} },				--Veldin1
+    {id=2,  location="Water works",			host_item="Aridia",   infobots={},           items={0x1E,0x1A,0x05} },		--Novalis
+    {id=3,  location="Save the Chairman",	host_item="Kerwan",   infobots={0x04},       items={0x0C,0x02,0x0F} },		--Novalis
+    {id=4,  location="Train",				host_item="Eudora",   infobots={0x06},       items={0x14,0x09} },			--Kerwan
+    {id=5,  location="Warship",				host_item="Rilgar",   infobots={0x07},       items={0x30,0x11,0x17} },		--Blarg
+    {id=6,  location="Robot Lieutenant",	host_item="Blarg",    infobots={0x05},       items={0x1D,0x16,0x0E} },		--Eudora
+    {id=7,  location="Qwark's Trailer",		host_item="Umbris",   infobots={0x08},       items={} },					--Rilgar
+    {id=8,  location="Snagglebeast",		host_item="Batalia",  infobots={0x09,0x0A},  items={0x1B,0x0B} },			--Umbris
+    {id=9,	location="Grind Rail",			host_item="Gaspar",   infobots={},           items={0x07,0x12} },			--Batalia
+    {id=10, location="Commando",			host_item="Orxon",    infobots={0x0B,0x0C},  items={0x34,0x35,0x1C,0x0D} },	--Batalia
+    {id=11, location="Clank 2nd Item",		host_item="Pokitaru", infobots={},           items={0x03,0x06,0x23,0x19} },	--Orxon
+    {id=12, location="Chase the Infobot",	host_item="Hoven",    infobots={0x0D},       items={0x31,0x04,0x18} },		--Orxon
+    {id=13, location="Turret Fight",		host_item="Gemlik",   infobots={0x0E},       items={} },					--Hoven
+    {id=14, location="Defeat Qwark",		host_item="Oltanis",  infobots={0x0F},       items={0x20,0x13,0x15} },		--Gemlik
+    {id=15, location="Deaf Guy",			host_item="Quartu",   infobots={0x10,0x11},  items={0x22} },				--Oltanis
+    {id=16,	location="Giant Clank Fight",	host_item="KaleboIII",infobots={},           items={0x1F,0x21} },			--Quartu
+    {id=17,	location="Clank's Mum",			host_item="Fleet",    infobots={0x12},       items={0x32} }					--Quartu
 }

--- a/logic1_Speed.lua
+++ b/logic1_Speed.lua
@@ -39,24 +39,24 @@ items = {
 }
 
 infobots = {
-    {id=0x01, req_items={} },												-- Novalis "infobot" on Veldin1 Clank
-    {id=0x02, req_items={} },												-- Aridia infobot on Novalis, Water works
-    {id=0x03, req_items={} },												-- Kerwan infobot on Novalis, Save the Chairman 
-    {id=0x04, req_items={{0x02}, {0x03}, {0x20}} },							-- Eudora infobot on Kerwan, Train
-    {id=0x05, req_items={} },												-- Rilgar infobot on Blarg, Warship
-    {id=0x06, req_items={{0x02}, {0x03}, {0x20}, {0x19}} },					-- Blarg infobot on Eudora, Robot Lieutenant
-    {id=0x07, req_items={{0x02}, {0x03}, {0x20}, {0x0C}} },					-- Umbris infobot on Rilgar, Qwark's Trailer
-    {id=0x08, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },					-- Batalia infobot on Umbris, Snagglebeast
-    {id=0x09, req_items={{0x1D}, {0x02}, {0x20}} },							-- Gaspar infobot on Batalia, Grind Rail
-    {id=0x0A, req_items={} },												-- Orxon infobot on Batalia, Commando
-    {id=0x0B, req_items={} },												-- Pokitaru infobot on Orxon, Clank 2
-    {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },			-- Hoven infobot on Orxon, Chase the infobot
-    {id=0x0D, req_items={} },												-- Gemlik infobot on Hoven, Turret Fight
     {id=0x0E, req_items={{0x0C,0x1C,0x1A,0x0B}, {0x02}, {0x03}, {0x20}} },	-- Oltanis infobot on Gemlik, Defeat Qwark
-    {id=0x0F, req_items={{0x1D}, {0x1C}, {0x20}} },							-- Quartu infobot on Oltanis, Deaf guy
-    {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },					-- KaleboIII infobot on Quartu, Giant Clank Fight
-    {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },							-- Fleet infobot on Quartu, Clank's Mum
-    {id=0x12, req_items={{0x03}, {0x1C}, {0x19}, {0x20}} }					-- Veldin2 infobot on Drek's Fleet, Battle through the ships
+    {id=0x01, req_items={} },																		-- Novalis "infobot" on Veldin1 Clank
+    {id=0x02, req_items={} },																		-- Aridia infobot on Novalis, Water works
+    {id=0x03, req_items={} },																		-- Kerwan infobot on Novalis, Save the Chairman 
+    {id=0x04, req_items={{0x02}, {0x03}, {0x20}} },													-- Eudora infobot on Kerwan, Train
+    {id=0x05, req_items={} },																		-- Rilgar infobot on Blarg, Warship
+    {id=0x06, req_items={{0x02}, {0x03}, {0x20}, {0x19}} },											-- Blarg infobot on Eudora, Robot Lieutenant
+    {id=0x07, req_items={{0x02}, {0x03}, {0x20}, {0x0C}} },											-- Umbris infobot on Rilgar, Qwark's Trailer
+    {id=0x08, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },											-- Batalia infobot on Umbris, Snagglebeast
+    {id=0x09, req_items={{0x1D}, {0x02}, {0x20}} },													-- Gaspar infobot on Batalia, Grind Rail
+    {id=0x0A, req_items={} },																		-- Orxon infobot on Batalia, Commando
+    {id=0x0B, req_items={} },																		-- Pokitaru infobot on Orxon, Clank 2
+    {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },									-- Hoven infobot on Orxon, Chase the infobot
+    {id=0x0D, req_items={} },																		-- Gemlik infobot on Hoven, Turret Fight
+    {id=0x0F, req_items={{0x1D}, {0x1C}, {0x20}} },													-- Quartu infobot on Oltanis, Deaf guy
+    {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },											-- KaleboIII infobot on Quartu, Giant Clank Fight
+    {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },													-- Fleet infobot on Quartu, Clank's Mum
+    {id=0x12, req_items={{0x03}, {0x1C}, {0x19}, {0x20}} }											-- Veldin2 infobot on Drek's Fleet, Battle through the ships
 }
 
 planets = {

--- a/logic1_Speed.lua
+++ b/logic1_Speed.lua
@@ -30,7 +30,7 @@ items = {
     {id=0x20,	location="Steve",				host_item="PDA",				req_items={{0x1C}} },																			--Oltanis
     {id=0x21,	location="Grind Rail",			host_item="Map-O-Matic",		req_items={{0x1D}, {0x20}} },																	--KaleboIII
     {id=0x22,	location="Water path",			host_item="Bolt Grabber",		req_items={{0x04, 0x06}, {0x20}, {0x02}, {0x03}} },												--Quartu
-    {id=0x23,	location="Water Lab",			host_item="Persuader",			req_items={{0x31, 0x1A, 0x16}, {0x31,0x06}} },													--Poki
+    {id=0x23,	location="Water Lab",			host_item="Persuader",			req_items={{0x31, 0x1A, 0x16}, {0x31,0x06}, {0x31, 0x19, 0x20}} },								--Poki
     {id=0x30,	location="Hoverboard Race",		host_item="Zoomerator",			req_items={{0x02}, {0x03}, {0x20}} },															--Rilgar
     {id=0x31,	location="Drill Guy",			host_item="Raritanium",			req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },													--Hoven
     {id=0x32,	location="Water path",			host_item="Codebot",			req_items={} },																					--Fleet
@@ -39,7 +39,6 @@ items = {
 }
 
 infobots = {
-    {id=0x0E, req_items={{0x0C,0x1C,0x1A,0x0B}, {0x02}, {0x03}, {0x20}} },	-- Oltanis infobot on Gemlik, Defeat Qwark
     {id=0x01, req_items={} },																		-- Novalis "infobot" on Veldin1 Clank
     {id=0x02, req_items={} },																		-- Aridia infobot on Novalis, Water works
     {id=0x03, req_items={} },																		-- Kerwan infobot on Novalis, Save the Chairman 
@@ -53,6 +52,7 @@ infobots = {
     {id=0x0B, req_items={} },																		-- Pokitaru infobot on Orxon, Clank 2
     {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },									-- Hoven infobot on Orxon, Chase the infobot
     {id=0x0D, req_items={} },																		-- Gemlik infobot on Hoven, Turret Fight
+    {id=0x0E, req_items={{0x0C,0x1C,0x1A,0x0B}, {0x0C,0x1C,0x1A,0x0D}, {0x02}, {0x03}, {0x20}} },	-- Oltanis infobot on Gemlik, Defeat Qwark
     {id=0x0F, req_items={{0x1D}, {0x1C}, {0x20}} },													-- Quartu infobot on Oltanis, Deaf guy
     {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },											-- KaleboIII infobot on Quartu, Giant Clank Fight
     {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },													-- Fleet infobot on Quartu, Clank's Mum

--- a/logic1_Speed.lua
+++ b/logic1_Speed.lua
@@ -3,7 +3,7 @@ items = {
     {id=0x03,	location="Bob's Shop",			host_item="Thruster-pack",		req_items={} },											 										--Poki
     {id=0x04,	location="Edwina's Shop",		host_item="Hydro-pack",			req_items={{0x16}, {0x02}, {0x03}, {0x20}} },													--Hoven
     {id=0x05,	location="Skidd's Agent",		host_item="Sonic Summoner",		req_items={{0x30}} },																			--Aridia
-    {id=0x06,	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07}} },																			--Poki
+    {id=0x06,	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07, 0x03}, {0x07, 0x19}} },														--Poki
     {id=0x07,	location="Pilot's Helmet",		host_item="Pilot's Helmet",		req_items={} },																					--Gaspar
     {id=0x09,	location="Suck Cannon",			host_item="Suck Cannon",		req_items={{0x02}, {0x03}, {0x20}} },															--Eudora
     {id=0x0B,	location="Vendor",				host_item="Devastator",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Batalia

--- a/logic2_Custom.lua
+++ b/logic2_Custom.lua
@@ -2,84 +2,83 @@
 Customized by Alados5 (Jun'22)
 Basically removed Batalia SI, ILJ/ISF ship to boss on Umbris, and a couple clips
 --]]
-
 items = {
-    {id=0x02, name="Heli-pack",       req_items={} },
-    {id=0x03, name="Thruster-pack",   req_items={} },
-    {id=0x04, name="Hydro-pack",      req_items={{0x16}, {0x02}, {0x03}} },
-    {id=0x05, name="Sonic Summoner",  req_items={{0x30}} },
-    {id=0x06, name="O2 Mask",         req_items={{0x07}} },
-    {id=0x07, name="Pilot's Helmet",  req_items={} },
-    {id=0x09, name="Suck Cannon",     req_items={{0x02}, {0x03}, {0x20}} },
-    {id=0x0B, name="Devastator",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x0C, name="Swingshot",       req_items={} },
-    {id=0x0D, name="Visibomb",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x0E, name="Taunter",         req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x0F, name="Blaster",         req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x10, name="Pyrocitor",       req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x11, name="Mine Glove",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x12, name="Walloper",        req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x13, name="Tesla Claw",      req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x14, name="Glove of Doom",   req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x15, name="Morph-O-Ray",     req_items={{0x0C}, {0x20}} },
-    {id=0x16, name="Hydrodisplacer",  req_items={{0x1A}, {0x02}, {0x03}, {0x20}} },
-    {id=0x17, name="R.Y.N.O.",        req_items={{0x1B,0x02}, {0x1B,0x03}} },
-    {id=0x18, name="Drone Device",    req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x19, name="Decoy Glove",     req_items={}, ill_items={0x30,0x31,0x32,0x34,0x35} },
-    {id=0x1A, name="Trespasser",      req_items={{0x0C}, {0x02}, {0x03}} },
-    {id=0x1B, name="MetalDetector",   req_items={{0x1C}, {0x02}, {0x03}} },
-    {id=0x1C, name="Magneboots",      req_items={} },
-    {id=0x1D, name="Grindboots",      req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },
-    {id=0x1E, name="Hoverboard",      req_items={} },
-    {id=0x1F, name="Hologuise",       req_items={{0x1E,0x02}, {0x1E,0x0D}, {0x03}, {0x20}} },
-    {id=0x20, name="PDA",             req_items={{0x1C}} },
-    {id=0x21, name="Map-O-Matic",     req_items={{0x1D}, {0x20,0x03}} },
-    {id=0x22, name="Bolt Grabber",    req_items={{0x04,0x06}, {0x20}} },
-    {id=0x23, name="Persuader",       req_items={{0x31,0x1A,0x16}} },
-    {id=0x30, name="Zoomerator",      req_items={{0x02}, {0x03}, {0x20}} },
-    {id=0x31, name="Raritanium",      req_items={{0x0C}, {0x02}, {0x03}} },
-    {id=0x32, name="Codebot",         req_items={} },
-    {id=0x34, name="Premium Nanotech",req_items={{0x06,0x02}, {0x06,0x03}, {0x06,0x20}} },
-    {id=0x35, name="Ultra Nanotech",  req_items={{0x34,0x06,0x02}, {0x34,0x06,0x03}, {0x34,0x06,0x20}} },
+    {id=0x02, 	location="Al's Shop",			host_item="Heli-pack",			req_items={} },													 								--Kerwan
+    {id=0x03,	location="Bob's Shop",			host_item="Thruster-pack",		req_items={} },											 										--Poki
+    {id=0x04,	location="Edwina's Shop",		host_item="Hydro-pack",			req_items={{0x16}, {0x02}, {0x03}} },															--Hoven
+    {id=0x05,	location="Skidd's Agent",		host_item="Sonic Summoner",		req_items={{0x30}} },																			--Aridia
+    {id=0x06,	location="Ship Fight",			host_item="O2 Mask",			req_items={{0x07}} },																			--Poki
+    {id=0x07,	location="Pilot's Helmet",		host_item="Pilot's Helmet",		req_items={} },																					--Gaspar
+    {id=0x09,	location="Suck Cannon",			host_item="Suck Cannon",		req_items={{0x02}, {0x03}, {0x20}} },															--Eudora
+    {id=0x0B,	location="Vendor",				host_item="Devastator",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Batalia
+    {id=0x0C,	location="Fitness Course",		host_item="Swingshot",			req_items={} },																					--Kerwan
+    {id=0x0D,	location="Vendor",				host_item="Visibomb",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Orxon
+    {id=0x0E,	location="Vendor",				host_item="Taunter",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Blarg
+    {id=0x0F,	location="Vendor",				host_item="Blaster",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Kerwan
+    {id=0x10,	location="Vendor",				host_item="Pyrocitor",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Novalis
+    {id=0x11,	location="Vendor",				host_item="Mine Glove",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Rilgar
+    {id=0x12,	location="Vendor",				host_item="Walloper",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Gaspar
+    {id=0x13,	location="Vendor",				host_item="Tesla Claw",			req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Oltanis
+    {id=0x14,	location="Vendor",				host_item="Glove of Doom",		req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Eudora
+    {id=0x15,	location="Morph-O-Ray",			host_item="Morph-O-Ray",		req_items={{0x0C}, {0x20}} },																	--Oltanis
+    {id=0x16,	location="Outside",				host_item="Hydrodisplacer",		req_items={{0x1A}, {0x02}, {0x03}, {0x20}} },													--Blarg
+    {id=0x17,	location="Shady Salesman",		host_item="R.Y.N.O.",			req_items={{0x1B, 0x02}, {0x1B, 0x03}} },														--Rilgar
+    {id=0x18,	location="Vendor",				host_item="Drone Device",		req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Hoven
+    {id=0x19,	location="Vendor",				host_item="Decoy Glove",		req_items={},											ill_items={0x30,0x31,0x32,0x34,0x35} },	--Poki
+    {id=0x1A,	location="Construction Zone",	host_item="Trespasser",			req_items={{0x0C}, {0x02}, {0x03} },															--Aridia
+    {id=0x1B,	location="Turret Fight", 		host_item="MetalDetector",		req_items={{0x1C}, {0x02}, {0x03} },															--Batalia
+    {id=0x1C,	location="Clank 1st Item",		host_item="Magneboots",			req_items={} },																					--Orxon
+    {id=0x1D,	location="Alien Queen",			host_item="Grindboots",			req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },													--Blarg
+    {id=0x1E,	location="Save Skidd",			host_item="Hoverboard",			req_items={} },																					--Aridia
+    {id=0x1F,	location="Hoverboard Race",		host_item="Hologuise",			req_items={{0x1E, 0x02}, {0x1E, 0x0D}, {0x03}, {0x20}} },										--KaleboIII
+    {id=0x20,	location="Steve",				host_item="PDA",				req_items={{0x1C}} },																			--Oltanis
+    {id=0x21,	location="Grind Rail",			host_item="Map-O-Matic",		req_items={{0x1D}, {0x20, 0x03}} },																--KaleboIII
+    {id=0x22,	location="Water path",			host_item="Bolt Grabber",		req_items={{0x04, 0x06}, {0x20} },																--Quartu
+    {id=0x23,	location="Water Lab",			host_item="Persuader",			req_items={{0x31, 0x1A, 0x16}, {0x31,0x06}} },													--Poki
+    {id=0x30,	location="Hoverboard Race",		host_item="Zoomerator",			req_items={{0x02}, {0x03}, {0x20}} },															--Rilgar
+    {id=0x31,	location="Drill Guy",			host_item="Raritanium",			req_items={{0x0C}, {0x02}, {0x03}} },															--Hoven
+    {id=0x32,	location="Water path",			host_item="Codebot",			req_items={} },																					--Fleet
+    {id=0x34,	location="Nanotech Vendor 1",	host_item="Premium Nanotech",	req_items={{0x06, 0x02}, {0x06, 0x03}, {0x06, 0x20}} },											--Orxon
+    {id=0x35,	location="Nanotech Vendor 2",	host_item="Ultra Nanotech",		req_items={{0x34, 0x06, 0x02}, {0x34, 0x06, 0x03}} },											--Orxon
 }
 
 infobots = {
-    {id=0x01, req_items={} },				                             -- Veldin1 -> Novalis
-    {id=0x02, req_items={} },				                             -- Novalis -> Aridia
-    {id=0x03, req_items={} },				                             -- Novalis -> Kerwan
-    {id=0x04, req_items={{0x02}, {0x03}} },                      -- Kerwan -> Eudora
-    {id=0x05, req_items={} },				                             -- Blarg -> Rilgar
-    {id=0x06, req_items={{0x02}, {0x03}, {0x19}} },              -- Eudora -> Blarg
-    {id=0x07, req_items={{0x02}, {0x03}} },                      -- Rilgar -> Umbris
-    {id=0x08, req_items={{0x0C,0x02}, {0x0C,0x03}} },            -- Umbris -> Batalia
-    {id=0x09, req_items={{0x1D}, {0x02,0x20}, {0x03,0x20}} },    -- Batalia -> Gaspar
-    {id=0x0A, req_items={} },				                             -- Batalia -> Orxon
-    {id=0x0B, req_items={} },				                             -- Orxon -> Pokitaru
-    {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}} },            -- Orxon -> Hoven
-    {id=0x0D, req_items={} },				                                       -- Hoven -> Gemlik
-    {id=0x0E, req_items={{0x0C,0x1C,0x1A,0x0B}, {0x02}, {0x03}, {0x20}} }, -- Gemlik -> Oltanis
-    {id=0x0F, req_items={{0x1D}, {0x20}} },                      -- Oltanis -> Quartu
-    {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },      -- Quartu -> KaleboIII
-    {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },              -- Quartu -> Fleet
-    {id=0x12, req_items={{0x03}, {0x1C}, {0x19}} }               -- Fleet -> Veldin2
+    {id=0x01, req_items={} },													-- Novalis "infobot" on Veldin1 Clank
+    {id=0x02, req_items={} },													-- Aridia infobot on Novalis, Water works
+    {id=0x03, req_items={} },													-- Kerwan infobot on Novalis, Save the Chairman 
+    {id=0x04, req_items={{0x02}, {0x03}} },										-- Eudora infobot on Kerwan, Train
+    {id=0x05, req_items={} },													-- Rilgar infobot on Blarg, Warship
+    {id=0x06, req_items={{0x02}, {0x03}, {0x19}} },								-- Blarg infobot on Eudora, Robot Lieutenant
+    {id=0x07, req_items={{0x02}, {0x03}} },										-- Umbris infobot on Rilgar, Qwark's Trailer
+    {id=0x08, req_items={{0x0C, 0x02}, {0x0C, 0x03}} },							-- Batalia infobot on Umbris, Snagglebeast
+    {id=0x09, req_items={{0x1D}, {0x02, 0x20}, {0x03, 0x20}} },					-- Gaspar infobot on Batalia, Grind Rail
+    {id=0x0A, req_items={} },													-- Orxon infobot on Batalia, Commando
+    {id=0x0B, req_items={} },													-- Pokitaru infobot on Orxon, Clank 2
+    {id=0x0C, req_items={{0x06,0x02}, {0x06,0x03}} },							-- Hoven infobot on Orxon, Chase the infobot
+    {id=0x0D, req_items={} },													-- Gemlik infobot on Hoven, Turret Fight
+    {id=0x0E, req_items={{0x0C, 0x1C, 0x1A, 0x0B}, {0x02}, {0x03}, {0x20}} },	-- Oltanis infobot on Gemlik, Defeat Qwark
+    {id=0x0F, req_items={{0x1D}, {0x20}} },										-- Quartu infobot on Oltanis, Deaf guy
+    {id=0x10, req_items={{0x0C}, {0x02}, {0x03}, {0x20}} },						-- KaleboIII infobot on Quartu, Giant Clank Fight
+    {id=0x11, req_items={{0x02}, {0x03}, {0x20}} },								-- Fleet infobot on Quartu, Clank's Mum
+    {id=0x12, req_items={{0x03}, {0x1C}, {0x19}} }								-- Veldin2 infobot on Drek's Fleet, Battle through the ships
 }
 
 planets = {
-    {id=1,  name="Novalis",  infobots={0x02,0x03},  items={0x10} },
-    {id=2,  name="Aridia",   infobots={},           items={0x1E,0x1A,0x05} },
-    {id=3,  name="Kerwan",   infobots={0x04},       items={0x0C,0x02,0x0F} },
-    {id=4,  name="Eudora",   infobots={0x06},       items={0x14,0x09} },
-    {id=5,  name="Rilgar",   infobots={0x07},       items={0x30,0x11,0x17} },
-    {id=6,  name="Blarg",    infobots={0x05},       items={0x1D,0x16,0x0E} },
-    {id=7,  name="Umbris",   infobots={0x08},       items={} },
-    {id=8,  name="Batalia",  infobots={0x09,0x0A},  items={0x1B,0x0B} },
-    {id=9,  name="Gaspar",   infobots={},           items={0x07,0x12} },
-    {id=10, name="Orxon",    infobots={0x0B,0x0C},  items={0x34,0x35,0x1C,0x0D} },
-    {id=11, name="Pokitaru", infobots={},           items={0x03,0x06,0x23,0x19} },
-    {id=12, name="Hoven",    infobots={0x0D},       items={0x31,0x04,0x18} },
-    {id=13, name="Gemlik",   infobots={0x0E},       items={} },
-    {id=14, name="Oltanis",  infobots={0x0F},       items={0x20,0x13,0x15} },
-    {id=15, name="Quartu",   infobots={0x10,0x11},  items={0x22} },
-    {id=16, name="KaleboIII",infobots={},           items={0x1F,0x21} },
-    {id=17, name="Fleet",    infobots={0x12},       items={0x32} }
+    {id=1,  location="Clank",				host_item="Novalis",  infobots={0x02,0x03},  items={0x10} },				--Veldin1
+    {id=2,  location="Water works",			host_item="Aridia",   infobots={},           items={0x1E,0x1A,0x05} },		--Novalis
+    {id=3,  location="Save the Chairman",	host_item="Kerwan",   infobots={0x04},       items={0x0C,0x02,0x0F} },		--Novalis
+    {id=4,  location="Train",				host_item="Eudora",   infobots={0x06},       items={0x14,0x09} },			--Kerwan
+    {id=5,  location="Warship",				host_item="Rilgar",   infobots={0x07},       items={0x30,0x11,0x17} },		--Blarg
+    {id=6,  location="Robot Lieutenant",	host_item="Blarg",    infobots={0x05},       items={0x1D,0x16,0x0E} },		--Eudora
+    {id=7,  location="Qwark's Trailer",		host_item="Umbris",   infobots={0x08},       items={} },					--Rilgar
+    {id=8,  location="Snagglebeast",		host_item="Batalia",  infobots={0x09,0x0A},  items={0x1B,0x0B} },			--Umbris
+    {id=9,	location="Grind Rail",			host_item="Gaspar",   infobots={},           items={0x07,0x12} },			--Batalia
+    {id=10, location="Commando",			host_item="Orxon",    infobots={0x0B,0x0C},  items={0x34,0x35,0x1C,0x0D} },	--Batalia
+    {id=11, location="Clank 2nd Item",		host_item="Pokitaru", infobots={},           items={0x03,0x06,0x23,0x19} },	--Orxon
+    {id=12, location="Chase the Infobot",	host_item="Hoven",    infobots={0x0D},       items={0x31,0x04,0x18} },		--Orxon
+    {id=13, location="Turret Fight",		host_item="Gemlik",   infobots={0x0E},       items={} },					--Hoven
+    {id=14, location="Defeat Qwark",		host_item="Oltanis",  infobots={0x0F},       items={0x20,0x13,0x15} },		--Gemlik
+    {id=15, location="Deaf Guy",			host_item="Quartu",   infobots={0x10,0x11},  items={0x22} },				--Oltanis
+    {id=16,	location="Giant Clank Fight",	host_item="KaleboIII",infobots={},           items={0x1F,0x21} },			--Quartu
+    {id=17,	location="Clank's Mum",			host_item="Fleet",    infobots={0x12},       items={0x32} }					--Quartu
 }

--- a/main.lua
+++ b/main.lua
@@ -3,10 +3,10 @@ require 'io'
 require 'crc32'
 require 'logicChosen'
 
-function GetItem(name)
+function GetItem(host_item)
 	for i, item in ipairs(items) do
-		if name == item[name] then
-			return item
+		if host_item == item[host_item] then
+			return host_item
 		end
 	end
 end
@@ -317,7 +317,7 @@ function Randomize(seed)
 
 
 		-- Try to fill available item slots to meet requirements for another out, starting with first available out
-		--filewrite("# Filling available outs for " .. found_planet.name .. "\n")
+		--filewrite("# Filling available outs for " .. found_planet.host_item .. "\n")
 		for i, out in pairs(available_outs) do
 			--filewrite("# Available out: " .. out .. "\n")
 			-- Try to fill the requirement in previous planets first
@@ -414,7 +414,7 @@ function Randomize(seed)
 								if value == requirements_left[1] then
 									requirements_left[#requirements_left + 1] = requirements_left[1]
 									table.remove(requirements_left, 1)
-									filewrite("# Encountered illegal item to replace " .. item_slot.item.name .. "\n")
+									filewrite("# Encountered illegal item to replace " .. item_slot.item.host_item .. "\n")
 									goto continue_requirement_search
 								end
 							end
@@ -444,7 +444,7 @@ function Randomize(seed)
 							n_requirements_met = 0
 							for kk, requirement in pairs(reqs) do
 								if requirement == requirements_left[1] then
-									--print(item_slot.item.name .. " can not be replaced with " .. GetItemWithID(requirements_left[1]).name)
+									--print(item_slot.item.location .. " can not be replaced with " .. GetItemWithID(requirements_left[1]).host_item)
 									can_meet = false
 									n_requirements_met = 0
 								end
@@ -452,22 +452,22 @@ function Randomize(seed)
 								can_meet = false
 								for jj, available_item in pairs(item_list) do
 									if requirement == available_item then
-										--print(item_slot.item.name .. " met a requirement for " .. GetItemWithID(requirements_left[1]).name .. ", even though it is a requirement in a different combination")
+										--print(item_slot.item.host_item .. " met a requirement for " .. GetItemWithID(requirements_left[1]).location .. ", even though it is a requirement in a different combination")
 										can_meet = true
-										--filewrite("# " .. GetItemWithID(requirements_left[1]).name .. " met requirement for " .. GetItemWithID(requirement).name .. "\n")
+										--filewrite("# " .. GetItemWithID(requirements_left[1]).host_item .. " met requirement for " .. GetItemWithID(requirement).location .. "\n")
 										--n_requirements_met = n_requirements_met + 1
 									end
 								end
 
 								if can_meet or has_item then
-									filewrite("# " .. GetItemWithID(requirements_left[1]).name .. " met requirement for " .. GetItemWithID(requirement).name .. "\n")
+									filewrite("# " .. GetItemWithID(requirements_left[1]).host_item .. " met requirement for " .. GetItemWithID(requirement).location .. "\n")
 
 									n_requirements_met = n_requirements_met + 1
 								end
 							end
 
 							if n_requirements_met >= #requirements then
-								filewrite("# " .. GetItemWithID(requirements_left[1]).name .. " n_requirements_met: " .. n_requirements_met .. ", #requirements: " .. #requirements .. "\n")
+								filewrite("# " .. GetItemWithID(requirements_left[1]).host_item .. " n_requirements_met: " .. n_requirements_met .. ", #requirements: " .. #requirements .. "\n")
 								can_meet = true
 								goto continue_item_assignment
 							end
@@ -480,7 +480,7 @@ function Randomize(seed)
 						::continue_item_assignment::
 
 						if not can_meet then  -- Can't meet requirements yet, put this requirement at end of list
-							--print("Can't meet requirements for " .. GetItemWithID(requirements_left[1]).name .. ", bumping to end of list. Available slots left: " .. #available_item_slots)
+							--print("Can't meet requirements for " .. GetItemWithID(requirements_left[1]).host_item .. ", bumping to end of list. Available slots left: " .. #available_item_slots)
 
 							local req = table.deepcopy(requirements_left[1])
 							table.remove(requirements_left, 1)
@@ -517,12 +517,12 @@ function Randomize(seed)
 							end
 
 							if item_slot.item.ill_items ~= nil then
-								filewrite('"' .. planets[item_slot.planet].name .. '" -> "' .. GetItemWithID(requirements_left[1]).name .. '\"[color="#ff0000",label="' .. item_slot.item.name .. '",fontsize=8]\n')
+								filewrite('"' .. planets[item_slot.planet].host_item .. '" -> "' .. GetItemWithID(requirements_left[1]).host_item .. '\"[color="#ff0000",label="' .. item_slot.item.location .. '",fontsize=8]\n')
 							else
-								filewrite('"' .. planets[item_slot.planet].name .. '" -> "' .. GetItemWithID(requirements_left[1]).name .. '\"[color="#00ff00",label="' .. item_slot.item.name .. '",fontsize=8]\n')
+								filewrite('"' .. planets[item_slot.planet].host_item .. '" -> "' .. GetItemWithID(requirements_left[1]).host_item .. '\"[color="#00ff00",label="' .. item_slot.item.location .. '",fontsize=8]\n')
 							end
 
-							--print(item_slot.item.name .. " -> " .. GetItemWithID(requirements_left[1]).name)
+							--print(item_slot.item.host_item .. " -> " .. GetItemWithID(requirements_left[1]).has_item)
 							item_list[item_slot.item.id] = requirements_left[1]
 
 							RemoveItem(remaining_items, requirements_left[1])
@@ -563,15 +563,15 @@ function Randomize(seed)
 		--print(available_outs[out_index].infobot.id .. " -> " .. found_planet.id)
 
 		if available_outs[out_index].planet == 0 then
-			filewrite('"Veldin1" -> "' .. found_planet.name .. '"[label="Novalis",fontsize=8]\n')
+			filewrite('"Veldin1" -> "' .. found_planet.host_item .. '"[label="Clank",fontsize=8]\n')
 		else
 			local orig_infobot_name = "Veldin2"
 
 			if available_outs[out_index].infobot.id < 18 then
-				orig_infobot_name = planets[available_outs[out_index].infobot.id].name  -- Fix special case for Veldin2
+				orig_infobot_name = planets[available_outs[out_index].infobot.id].host_item  -- Fix special case for Veldin2
 			end
 
-			filewrite('"' .. planets[available_outs[out_index].planet].name .. '" -> "' .. found_planet.name .. '"[label="' .. orig_infobot_name .. '",fontsize=8]\n')
+			filewrite('"' .. planets[available_outs[out_index].planet].host_item .. '" -> "' .. found_planet.host_item .. '"[label="' .. orig_infobot_name .. '",fontsize=8]\n')
 		end
 
 		planet_list[available_outs[out_index].infobot.id] = found_planet.id  -- Replace infobot with next planet we found
@@ -581,8 +581,8 @@ function Randomize(seed)
 		-- Add Veldin2 to list of available planets if we've placed all other planets.
 		-- This doesn't necessarily make the longest path, but it's good enough for me.
 		if #available_planets <= 0 and #available_outs > 0 then
-			available_planets[1] = {id=18,name="Veldin2",  infobots={}, items={}}
-			planets[18] = {id=18,name="Veldin2",  infobots={}, items={}}
+			available_planets[1] = {id=18,location="Battle through the ships",host_item="Veldin2",  infobots={}, items={}}
+			planets[18] = {id=18,host_item="Veldin2",  infobots={}, items={}}
 		end
 
 		if #available_planets <= 0 then
@@ -614,12 +614,12 @@ function Randomize(seed)
 		end
 
 		if item_slot.item.ill_items ~= nil then
-			filewrite('"' .. planets[item_slot.planet].name .. '" -> "' .. remaining_items[1].name .. '\"[color="#ff00ff",label="' .. item_slot.item.name .. '",fontsize=8]\n')
+			filewrite('"' .. planets[item_slot.planet].host_item .. '" -> "' .. remaining_items[1].host_item .. '\"[color="#ff00ff",label="' .. item_slot.item.location .. '",fontsize=8]\n')
 		else
-			filewrite('"' .. planets[item_slot.planet].name .. '" -> "' .. remaining_items[1].name .. '\"[color="#0000ff",label="' .. item_slot.item.name .. '",fontsize=8]\n')
+			filewrite('"' .. planets[item_slot.planet].host_item .. '" -> "' .. remaining_items[1].host_item .. '\"[color="#0000ff",label="' .. item_slot.item.location .. '",fontsize=8]\n')
 		end
 
-		--print(item_slot.item.name .. " -> " .. remaining_items[1].name)
+		--print(item_slot.item.host_item .. " -> " .. remaining_items[1].host_item)
 
 
 		item_list[item_slot.item.id] = remaining_items[1].id


### PR DESCRIPTION
### Descriptive Location Names
Locations have a different name to their original item, for example "Al's Shop" will have a random item but the Heli-pack will still be listed wherever it has been randomized to. These location names have been given similar if not identical names to the in game mission associated with the map marker for the location.

### Logic fixes

#### Casual

- Thruster Pack is required to reach the Pokitaru Ship Fight.
- Qwarks trailer requires Heli/Thruster pack in casual.
- Umbris Snagglebeast fight requires at least one decent weapon.
- Hoven Helicopter has more weapons that are capable of destroying it.

#### Speedtech

- Thruster Pack or Decoy Glove is required to reach the Pokitaru Ship Fight.
- "Fred" at Pokitaru Underwater Lab can be reached with decoy clip and then PDA jumps when out of bounds.
- Add the Visibomb as a possible weapon for completing Gemlik.


**CURRENTLY UNTESTED**